### PR TITLE
Create a plugin initialize code for the usercache

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,13 +22,15 @@
   <platform name="android">
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="UserCache">
-        <param name="android-package" value="edu.berkeley.eecs.emission.cordova.usercache.UserCache"/>
+        <param name="android-package" value="edu.berkeley.eecs.emission.cordova.usercache.UserCachePlugin"/>
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 
     <source-file src="src/android/UserCacheFactory.java" target-dir="src/edu/berkeley/eecs/emission/cordova/usercache"/>
     <source-file src="src/android/UserCache.java" target-dir="src/edu/berkeley/eecs/emission/cordova/usercache"/>
     <source-file src="src/android/BuiltinUserCache.java" target-dir="src/edu/berkeley/eecs/emission/cordova/usercache"/>
+    <source-file src="src/android/UserCachePlugin.java" target-dir="src/edu/berkeley/eecs/emission/cordova/usercache"/>
     <resource-file src="res/android/usercachekeys.xml" target="res/values/usercachekeys.xml"/>
   </platform>
 

--- a/src/android/UserCachePlugin.java
+++ b/src/android/UserCachePlugin.java
@@ -1,0 +1,28 @@
+package edu.berkeley.eecs.emission.cordova.usercache;
+
+import org.apache.cordova.*;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import android.content.Context;
+
+import edu.berkeley.eecs.emission.R;
+import edu.berkeley.eecs.emission.cordova.usercache.UserCacheFactory;
+
+public class UserCachePlugin extends CordovaPlugin {
+
+    protected void pluginInitialize() {
+        // Let's just access the usercache so that it is created
+        UserCache currCache = UserCacheFactory.getUserCache(cordova.getActivity());
+        System.out.println("During plugin initialize, created usercache" + currCache);
+        // we need to put some kind of message - the table is created lazily during first use
+        currCache.putMessage(R.string.key_usercache_transition, "app launched");
+    }
+
+    @Override
+    public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
+        callbackContext.error("Not implemented");
+        return false;
+    }
+}
+


### PR DESCRIPTION
This ensures that the table exists on startup, so that we don't get the "table
not found" error from javascript when we try to access it. Note that we already
have a similar plugin on iOS, so this just unifies the two platforms.