### PR TITLE
Fix app crash during sync

### DIFF
--- a/src/android/BuiltinUserCache.java
+++ b/src/android/BuiltinUserCache.java
@@ -424,11 +424,8 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
 
         Log.d(cachedCtx, TAG, "Query is "+selectQuery);
         SQLiteDatabase db = this.getReadableDatabase();
-        Log.d(cachedCtx, TAG, "db is "+db);
         Cursor queryVal = db.rawQuery(selectQuery, null);
-        Log.d(cachedCtx, TAG, "queryVal = "+queryVal);
 
-        Log.d(cachedCtx, TAG, "moveToFirst() = "+queryVal.moveToFirst());
         int resultCount = queryVal.getCount();
         Log.d(cachedCtx, TAG, "Result count = "+resultCount);
         JSONArray entryArray = new JSONArray();


### PR DESCRIPTION
I ran into this really weird, 100% reproducible crash while syncing my data
into the server. This would happen consistently even when I hit "force sync"
from the UI, although it had clearly been working with the same version until a
few days ago (until the 7th, to be precise).

After pretty much a whole day of debugging, was able to fix it by making the
following changes.
- Adding parantheses to the query to get the entries to push
- Changing all the code to read timestamps from long to double, consistent with
    our change to use seconds instead of milliseconds on android as well

I also added some code to close cursors properly while reading the last
transition. This was not the root cause of the problem, but it is a Good Thing
to do anyway, so let's keep it in place. Although, this makes the code a little
ugly - we may want to refactor to make it easier to clean up resources.