### PR TITLE
Unify the access to the usercache through the native plugin

### DIFF
--- a/src/android/BuiltinUserCache.java
+++ b/src/android/BuiltinUserCache.java
@@ -163,12 +163,8 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
     }
 
     @Override
-    public JSONObject getDocument(String key) throws JSONException {
-        String docString = getDocumentString(key);
-        if (docString != null) {
-            return new JSONObject(docString);
-        }
-        return null;
+    public String getDocument(String key) throws JSONException {
+        return getDocumentString(key);
     }
 
     private String getDocumentString(String key) {

--- a/src/android/BuiltinUserCache.java
+++ b/src/android/BuiltinUserCache.java
@@ -620,5 +620,21 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         db.close();
     }
 
+
+    /*
+     * TODO: This should probably be moved into the usercache somehow
+     */
+    public static UserCache.TimeQuery getTimeQuery(Context cachedContext, JSONArray pointList) throws JSONException {
+        long start_ts = pointList.getJSONObject(0).getJSONObject("metadata").getLong("write_ts");
+        long end_ts = pointList.getJSONObject(pointList.length() - 1).getJSONObject("metadata").getLong("write_ts");
+        // This might still have a race in which there are new entries added with the same timestamp as the last
+        // entry. Use an id instead? Or manually choose a slightly earlier ts to be on the safe side?
+        // TODO: Need to figure out which one to do
+        // Start slightly before and end slightly after to make sure that we get all entries
+        UserCache.TimeQuery tq = new UserCache.TimeQuery(cachedContext.getString(R.string.metadata_usercache_write_ts),
+                start_ts - 1, end_ts + 1);
+        return tq;
+    }
+
     // END: Methods invoked for syncing the data to the host. Not part of the interface.
 }

--- a/src/android/UserCache.java
+++ b/src/android/UserCache.java
@@ -90,7 +90,9 @@ public interface UserCache {
          * and returned.
          */
     public abstract <T> T getDocument(int key, Class<T> classOfT);
-    public abstract JSONObject getDocument(String key) throws JSONException;
+    // Can be either JSONObject or JSONArray, and they don't have a common superclass other than
+    // object
+    public abstract String getDocument(String key) throws JSONException;
 
     /**
      * Delete documents that match the specified time query.

--- a/src/android/UserCache.java
+++ b/src/android/UserCache.java
@@ -1,23 +1,51 @@
 package edu.berkeley.eecs.emission.cordova.usercache;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONArray;
+
 /**
  * Abstract superclass for the client side component of the user cache.
  */
 public interface UserCache {
 
     class TimeQuery {
-        int keyRes;
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public double getStartTs() {
+            return startTs;
+        }
+
+        public void setStartTs(double startTs) {
+            this.startTs = startTs;
+        }
+
+        public double getEndTs() {
+            return endTs;
+        }
+
+        public void setEndTs(double endTs) {
+            this.endTs = endTs;
+        }
+
+        String key;
         double startTs;
         double endTs;
 
-        public TimeQuery(int keyRes, double startTs, double endTs) {
-            this.keyRes = keyRes;
+        public TimeQuery(String key, double startTs, double endTs) {
+            this.key = key;
             this.startTs = startTs;
             this.endTs = endTs;
         }
 
         public String toString() {
-            return startTs + " < " + keyRes + " < " + endTs;
+            return startTs + " < " + key + " < " + endTs;
         }
     }
 
@@ -26,31 +54,53 @@ public interface UserCache {
       Most objects are, but it would be good to confirm, probably by
       adding a serialization/deserialization test to WrapperTest.
      */
-    public abstract void putSensorData(int keyRes, Object value);
+    public abstract void putSensorData(int key, Object value);
+    public abstract void putMessage(int key, Object value);
+    public abstract void putReadWriteDocument(int key, Object value);
 
-    public abstract void putMessage(int keyRes, Object value);
+    /*
+     Versions that save JSON objects directly. For use with the plugin interface.
+     */
+    public abstract void putSensorData(String key, JSONObject value);
+    public abstract void putMessage(String key, JSONObject value);
+    public abstract void putReadWriteDocument(String key, JSONObject value);
 
-    public abstract void putReadWriteDocument(int keyRes, Object value);
+    // Versions that return an object retrieved via GSON. These are intended for use with native code.
+    public abstract <T> T[] getMessagesForInterval(int key, TimeQuery tq, Class<T> classOfT);
+    public abstract <T> T[] getSensorDataForInterval(int key, TimeQuery tq, Class<T> classOfT);
 
-    // TODO: Should this return a JSON object or an actual object retrieved via gson?
+    public abstract <T> T[] getLastMessages(int key, int nEntries, Class<T> classOfT);
+    public abstract <T> T[] getLastSensorData(int key, int nEntries, Class<T> classOfT);
 
-    public abstract <T> T[] getMessagesForInterval(int keyRes, TimeQuery tq, Class<T> classOfT);
-    public abstract <T> T[] getSensorDataForInterval(int keyRes, TimeQuery tq, Class<T> classOfT);
+    // Versions that return a raw JSON object. These are intended for use with the plugin.
+    // Note that for the plugin to use the prior interface, we would need to keep a mapping
+    // of keys to wrapper objects, which is:
+    // a) cumbersome and
+    // b) not necessary when the objects are not consumed in native code
+    // c) wasted cycles JSON -> GSON -> JSON
+    public abstract JSONArray getMessagesForInterval(String key, TimeQuery tq) throws JSONException;
+    public abstract JSONArray getSensorDataForInterval(String key, TimeQuery tq) throws JSONException;
 
-    public abstract <T> T[] getLastMessages(int keyRes, int nEntries, Class<T> classOfT);
-    public abstract <T> T[] getLastSensorData(int keyRes, int nEntries, Class<T> classOfT);
+    public abstract JSONArray getLastMessages(String key, int nEntries) throws JSONException;
+    public abstract JSONArray getLastSensorData(String key, int nEntries) throws JSONException;
 
         /**
          * Return the document that matches the specified key.
          * The class of T needs to be passed in, and an appropriate type will be reconstructed
          * and returned.
          */
-    public abstract <T> T getDocument(int keyRes, Class<T> classOfT);
-    public abstract <T> T getUpdatedDocument(int keyRes, Class<T> classOfT);
+    public abstract <T> T getDocument(int key, Class<T> classOfT);
+    public abstract JSONObject getDocument(String key) throws JSONException;
 
     /**
      * Delete documents that match the specified time query.
      * This allows us to support eventual consistency without locking.
      */
     public abstract void clearEntries(TimeQuery tq);
+    public abstract void invalidateCache(TimeQuery tq);
+
+    /*
+     * Nuclear option to recover from bad state
+     */
+    public abstract void clear();
 }

--- a/src/android/UserCachePlugin.java
+++ b/src/android/UserCachePlugin.java
@@ -35,6 +35,12 @@ public class UserCachePlugin extends CordovaPlugin {
         if (action.equals("getDocument")) {
             final String documentKey = data.getString(0);
             JSONObject doc = UserCacheFactory.getUserCache(ctxt).getDocument(documentKey);
+            if (doc == null) {
+                // Cordova doesn't like us to return with an empty objectA
+                // because then we get an NPE while initializing the result
+                // https://github.com/apache/cordova-android/blob/457c5b8b3b694265c991b456b15015741ade5014/framework/src/org/apache/cordova/PluginResult.java#L52
+                doc = new JSONObject();
+            }
             callbackContext.success(doc);
             return true;
         } else if (action.equals("getSensorDataForInterval")) {
@@ -92,14 +98,20 @@ public class UserCachePlugin extends CordovaPlugin {
             final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(),
                     UserCache.TimeQuery.class);
             UserCacheFactory.getUserCache(ctxt).clearEntries(timeQuery);
+            callbackContext.success();
+            return true;
         } else if (action.equals("invalidateCache")) {
             final JSONObject tqJsonObject = data.getJSONObject(1);
 
             final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(),
                     UserCache.TimeQuery.class);
             UserCacheFactory.getUserCache(ctxt).invalidateCache(timeQuery);
+            callbackContext.success();
+            return true;
         } else if (action.equals("clearAll")) {
             UserCacheFactory.getUserCache(ctxt).clear();
+            callbackContext.success();
+            return true;
         }
         return false;
     }

--- a/src/android/UserCachePlugin.java
+++ b/src/android/UserCachePlugin.java
@@ -7,12 +7,17 @@ import org.json.JSONObject;
 
 import android.content.Context;
 
+import com.google.gson.Gson;
+
 import edu.berkeley.eecs.emission.R;
-import edu.berkeley.eecs.emission.cordova.usercache.UserCacheFactory;
 
 public class UserCachePlugin extends CordovaPlugin {
 
     protected void pluginInitialize() {
+        // TODO: Figure out whether we still need this, given that we are using the standard usercache
+        // interface anyway. But for now, we will retain it because otherwise, I am not sure how
+        // best to deal with this.
+
         // Let's just access the usercache so that it is created
         UserCache currCache = UserCacheFactory.getUserCache(cordova.getActivity());
         System.out.println("During plugin initialize, created usercache" + currCache);
@@ -26,7 +31,76 @@ public class UserCachePlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
-        callbackContext.error("Not implemented");
+        Context ctxt = cordova.getActivity();
+        if (action.equals("getDocument")) {
+            final String documentKey = data.getString(0);
+            JSONObject doc = UserCacheFactory.getUserCache(ctxt).getDocument(documentKey);
+            callbackContext.success(doc);
+            return true;
+        } else if (action.equals("getSensorDataForInterval")) {
+            final String key = data.getString(0);
+            final JSONObject tqJsonObject = data.getJSONObject(1);
+            final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(), UserCache.TimeQuery.class);
+            JSONArray result = UserCacheFactory.getUserCache(ctxt)
+                    .getSensorDataForInterval(key, timeQuery);
+            callbackContext.success(result);
+            return true;
+        } else if (action.equals("getMessagesForInterval")) {
+            final String key = data.getString(0);
+            final JSONObject tqJsonObject = data.getJSONObject(1);
+            final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(),
+                    UserCache.TimeQuery.class);
+            JSONArray result = UserCacheFactory.getUserCache(ctxt)
+                    .getMessagesForInterval(key, timeQuery);
+            callbackContext.success(result);
+            return true;
+        } else if (action.equals("getLastMessages")) {
+            final String key = data.getString(0);
+            final int nEntries = data.getInt(1);
+            JSONArray result = UserCacheFactory.getUserCache(ctxt)
+                    .getLastMessages(key, nEntries);
+            callbackContext.success(result);
+            return true;
+        } else if (action.equals("getLastSensorData")) {
+            final String key = data.getString(0);
+            final int nEntries = data.getInt(1);
+            JSONArray result = UserCacheFactory.getUserCache(ctxt)
+                    .getLastSensorData(key, nEntries);
+            callbackContext.success(result);
+            return true;
+        } else if (action.equals("putMessage")) {
+            final String key = data.getString(0);
+            final JSONObject msg = data.getJSONObject(1);
+            UserCacheFactory.getUserCache(ctxt).putMessage(key, msg);
+            callbackContext.success();
+            return true;
+        } else if (action.equals("putRWDocument")) {
+            final String key = data.getString(0);
+            final JSONObject msg = data.getJSONObject(1);
+            UserCacheFactory.getUserCache(ctxt).putReadWriteDocument(key, msg);
+            callbackContext.success();
+            return true;
+        } else if (action.equals("putSensorData")) {
+            final String key = data.getString(0);
+            final JSONObject msg = data.getJSONObject(1);
+            UserCacheFactory.getUserCache(ctxt).putSensorData(key, msg);
+            callbackContext.success();
+            return true;
+        } else if (action.equals("clearEntries")) {
+            final JSONObject tqJsonObject = data.getJSONObject(1);
+
+            final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(),
+                    UserCache.TimeQuery.class);
+            UserCacheFactory.getUserCache(ctxt).clearEntries(timeQuery);
+        } else if (action.equals("invalidateCache")) {
+            final JSONObject tqJsonObject = data.getJSONObject(1);
+
+            final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(),
+                    UserCache.TimeQuery.class);
+            UserCacheFactory.getUserCache(ctxt).invalidateCache(timeQuery);
+        } else if (action.equals("clearAll")) {
+            UserCacheFactory.getUserCache(ctxt).clear();
+        }
         return false;
     }
 }

--- a/src/android/UserCachePlugin.java
+++ b/src/android/UserCachePlugin.java
@@ -34,14 +34,20 @@ public class UserCachePlugin extends CordovaPlugin {
         Context ctxt = cordova.getActivity();
         if (action.equals("getDocument")) {
             final String documentKey = data.getString(0);
-            JSONObject doc = UserCacheFactory.getUserCache(ctxt).getDocument(documentKey);
-            if (doc == null) {
+            String docStr = UserCacheFactory.getUserCache(ctxt).getDocument(documentKey);
+            if (docStr == null) {
                 // Cordova doesn't like us to return with an empty objectA
                 // because then we get an NPE while initializing the result
                 // https://github.com/apache/cordova-android/blob/457c5b8b3b694265c991b456b15015741ade5014/framework/src/org/apache/cordova/PluginResult.java#L52
-                doc = new JSONObject();
+                callbackContext.success(new JSONObject());
+            } else {
+                try {
+                    callbackContext.success(new JSONObject(docStr));
+                } catch (JSONException e) {
+                    System.out.println("document was not a JSONObject, trying JSONArray");
+                    callbackContext.success(new JSONArray(docStr));
+                }
             }
-            callbackContext.success(doc);
             return true;
         } else if (action.equals("getSensorDataForInterval")) {
             final String key = data.getString(0);

--- a/src/ios/BEMBuiltinUserCache.h
+++ b/src/ios/BEMBuiltinUserCache.h
@@ -21,11 +21,21 @@
 + (NSString*) getCurrentTimeSecsString;
 
 -(NSDictionary*)createSensorData:key write_ts:(NSDate*)write_ts timezone:(NSString*)tz data:(NSObject*)data;
+-(NSString*) getStatName:(NSString*)plistKey;
 
 // We implement the same interface as the android code, to use somewhat tested code
+
+// Versions that save wrapper classes, for use with native code
 - (void) putSensorData:(NSString*) label value:(NSObject*)value;
 - (void) putMessage:(NSString*) label value:(NSObject*)value;
 - (void)putReadWriteDocument:(NSString*)label value:(NSObject*)value;
+
+// Versions that save JSON directly, for use with the plugin
+- (void) putSensorData:(NSString*) label jsonValue:(NSDictionary*)value;
+- (void) putMessage:(NSString*) label jsonValue:(NSDictionary*)value;
+- (void)putReadWriteDocument:(NSString*)label jsonValue:(NSDictionary*)value;
+
+// Versions that return a particular wrapper class, for use with the native code
 
 - (NSArray*) getSensorDataForInterval:(NSString*) key tq:(TimeQuery*)tq wrapperClass:(Class)cls;
 - (NSArray*) getLastSensorData:(NSString*) key nEntries:(int)nEntries wrapperClass:(Class)cls;
@@ -33,6 +43,15 @@
 - (NSArray*) getMessageForInterval:(NSString*) key tq:(TimeQuery*)tq wrapperClass:(Class)cls;
 - (NSArray*) getLastMessage:(NSString*) key nEntries:(int)nEntries wrapperClass:(Class)cls;
 - (NSObject*) getDocument:(NSString*)key wrapperClass:(Class)cls;
+
+// Versions that return JSON, for use with the plugin interface
+
+- (NSArray*) getSensorDataForInterval:(NSString*) key tq:(TimeQuery*)tq;
+- (NSArray*) getLastSensorData:(NSString*) key nEntries:(int)nEntries;
+
+- (NSArray*) getMessageForInterval:(NSString*) key tq:(TimeQuery*)tq;
+- (NSArray*) getLastMessage:(NSString*) key nEntries:(int)nEntries;
+- (NSDictionary*) getDocument:(NSString*)key;
 
 - (double) getTsOfLastTransition;
 - (NSArray*) syncPhoneToServer;
@@ -43,5 +62,6 @@
 + (NSDate*) getWriteTs:(NSDictionary*)entry;
 
 - (void) clearEntries:(TimeQuery*)tq;
+- (void) invalidateCache:(TimeQuery*)tq;
 - (void) clear;
 @end

--- a/src/ios/BEMUserCachePlugin.h
+++ b/src/ios/BEMUserCachePlugin.h
@@ -1,4 +1,19 @@
 #import <Cordova/CDV.h>
 
 @interface BEMUserCachePlugin: CDVPlugin
+
+- (void) pluginInitialize;
+
+- (void) getDocument:(CDVInvokedUrlCommand*)command;
+- (void) getSensorDataForInterval:(CDVInvokedUrlCommand*)command;
+- (void) getMessagesForInterval:(CDVInvokedUrlCommand*)command;
+- (void) getLastMessages:(CDVInvokedUrlCommand*)command;
+- (void) getLastSensorData:(CDVInvokedUrlCommand *)command;
+- (void) putMessage:(CDVInvokedUrlCommand *)command;
+- (void) putRWDocument:(CDVInvokedUrlCommand *)command;
+- (void) putSensorData:(CDVInvokedUrlCommand *)command;
+- (void) clearEntries:(CDVInvokedUrlCommand *)command;
+- (void) invalidateCache:(CDVInvokedUrlCommand *)command;
+- (void) clearAll:(CDVInvokedUrlCommand *)command;
+
 @end

--- a/src/ios/BEMUserCachePlugin.m
+++ b/src/ios/BEMUserCachePlugin.m
@@ -1,5 +1,6 @@
 #import "BEMUserCachePlugin.h"
 #import "BEMBuiltinUserCache.h"
+#import "DataUtils.h"
 
 @implementation BEMUserCachePlugin
 
@@ -11,5 +12,240 @@
     NSLog(@"BEMUserCache:pluginInitialize singleton -> initialize native DB");
     NSLog(@"Database is %@", [BuiltinUserCache database]);
 }
+
+- (void) getDocument:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSDictionary* resultDoc = [[BuiltinUserCache database] getDocument:key];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsDictionary:resultDoc];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting document, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                       resultWithStatus:CDVCommandStatus_ERROR
+                                       messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) getSensorDataForInterval:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSDictionary* timequeryDoc = [command.arguments objectAtIndex:1];
+        TimeQuery* timequery = [TimeQuery new];
+        [DataUtils dictToWrapper:timequeryDoc wrapper:timequery];
+        NSArray* resultDoc = [[BuiltinUserCache database] getSensorDataForInterval:key tq:timequery];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsArray:resultDoc];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting sensor data, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) getMessagesForInterval:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSDictionary* timequeryDoc = [command.arguments objectAtIndex:1];
+        TimeQuery* timequery = [TimeQuery new];
+        [DataUtils dictToWrapper:timequeryDoc wrapper:timequery];
+        NSArray* resultDoc = [[BuiltinUserCache database] getMessageForInterval:key tq:timequery];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsArray:resultDoc];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting messages, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    
+}
+
+- (void) getLastMessages:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSString* nEntriesStr = [command.arguments objectAtIndex:1];
+        int nEntries = [nEntriesStr intValue];
+        NSArray* resultDoc = [[BuiltinUserCache database] getLastMessage:key nEntries:nEntries];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsArray:resultDoc];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While get last messages, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) getLastSensorData:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSString* nEntriesStr = [command.arguments objectAtIndex:1];
+        int nEntries = [nEntriesStr intValue];
+        NSArray* resultDoc = [[BuiltinUserCache database] getLastMessage:key nEntries:nEntries];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsArray:resultDoc];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting last messages, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) putMessage:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSDictionary* value = [command.arguments objectAtIndex:1];
+
+        [[BuiltinUserCache database] putMessage:key value:value];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While putting message, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) putRWDocument:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSDictionary* value = [command.arguments objectAtIndex:1];
+        
+        [[BuiltinUserCache database] putReadWriteDocument:key value:value];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While putting RW document, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) putSensorData:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSDictionary* value = [command.arguments objectAtIndex:1];
+        
+        [[BuiltinUserCache database] putSensorData:key value:value];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While putting sensor data, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) clearEntries:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSDictionary* timequeryDoc = [command.arguments objectAtIndex:0];
+        TimeQuery* timequery = [TimeQuery new];
+        [DataUtils dictToWrapper:timequeryDoc wrapper:timequery];
+        [[BuiltinUserCache database] clearEntries:timequery];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting sensor data, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) invalidateCache:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSDictionary* timequeryDoc = [command.arguments objectAtIndex:0];
+        TimeQuery* timequery = [TimeQuery new];
+        [DataUtils dictToWrapper:timequeryDoc wrapper:timequery];
+        [[BuiltinUserCache database] invalidateCache:timequery];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting sensor data, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) clearAll:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        [[BuiltinUserCache database] clear];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting sensor data, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
 
 @end

--- a/src/ios/BEMUserCachePlugin.m
+++ b/src/ios/BEMUserCachePlugin.m
@@ -19,6 +19,9 @@
     @try {
         NSString* key = [[command arguments] objectAtIndex:0];
         NSDictionary* resultDoc = [[BuiltinUserCache database] getDocument:key];
+        if (resultDoc == NULL) {
+            resultDoc = [NSDictionary new];
+        }
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK
                                    messageAsDictionary:resultDoc];

--- a/www/usercache.js
+++ b/www/usercache.js
@@ -25,10 +25,20 @@ var UserCache = {
         });
     },
 
-    getAllSensorDataForInterval: function(key) {
+    isEmptyDoc: function(resultDoc) {
+        /*
+         * Checks to see if the returned document is empty. Needed because we can't return
+         * null from android plugins, so we return the empty document instead, but
+         * then we need to check for it.
+         * https://github.com/apache/cordova-android/blob/457c5b8b3b694265c991b456b15015741ade5014/framework/src/org/apache/cordova/PluginResult.java#L52
+         */
+        return (Object.keys(resultDoc).length) == 0
+    },
+
+    getAllSensorData: function(key) {
         return UserCache.getSensorDataForInterval(key, UserCache.getAllTimeQuery());
     },
-    getAllMessagesForInterval: function(key) {
+    getAllMessages: function(key) {
         return UserCache.getMessagesForInterval(key, UserCache.getAllTimeQuery());
     },
     getSensorDataForInterval: function(key, tq) {

--- a/www/usercache.js
+++ b/www/usercache.js
@@ -19,157 +19,96 @@ var UserCache = {
     DOCUMENT_TYPE: "document",
     RW_DOCUMENT_TYPE: "rw-document",
 
-    /*
-     * If this is not done, then we may read read the table before making any
-     * native calls, and on iOS, that will cause us to create a loggerDB
-     * instead of copying the template.
-     */
-    db: function() {
-        // One handle for each thread
-        if (UserCache.dbHandle == null) {
-            UserCache.dbHandle = window.sqlitePlugin.openDatabase({
-                name: "userCacheDB",
-                location: 2,
-                createFromLocation: 1
-            });
-        }
-        return UserCache.dbHandle;
-    },
-
     getDocument: function(key) {
         return new Promise (function(resolve, reject){
-            UserCache.db().readTransaction(function(tx) {
-            /*
-             * We can have multiple entries for a particular key as the document associated with the key
-             * is updated throughout the day. We should really override as part of the sync. But for now,
-             * will deal with it in the client by retrieving the last entry.
-             */
-            var selQuery = "SELECT "+UserCache.KEY_DATA+" FROM "+UserCache.TABLE_USER_CACHE +
-                " WHERE "+ UserCache.KEY_KEY + " = '" + key + "'" +
-                " AND ("+ UserCache.KEY_TYPE + " = '" + UserCache.DOCUMENT_TYPE + "'" +
-                  " OR "+ UserCache.KEY_TYPE + " = '" + UserCache.RW_DOCUMENT_TYPE+ "') "+
-                  "ORDER BY "+UserCache.KEY_WRITE_TS+" DESC LIMIT 1";
-            window.Logger.log(window.Logger.LEVEL_INFO, "About to execute query "+selQuery+" against userCache")
-            tx.executeSql(selQuery,
-                [],
-                function(tx, data) {
-                    var resultList = [];
-                    console.log("Result has "+data.rows.length+" rows");
-                    for (i = 0; i < data.rows.length; i++) {
-                        resultList.push(data.rows.item(i)[UserCache.KEY_DATA]);
-                    }
-                    resolve(resultList);
-                }, function(tx, response) {
-                    reject(response);
-                });
-            });
+            exec(resolve, reject, "UserCache", "getDocument", [key])
         });
     },
 
-    getSensorData: function(key, successCallback, errorCallback) {
-        UserCache.getEntries(UserCache.SENSOR_DATA_TYPE, key, successCallback, errorCallback);
+    getAllSensorDataForInterval: function(key) {
+        return UserCache.getSensorDataForInterval(key, UserCache.getAllTimeQuery());
     },
-
-    getMessages: function(key, successCallback, errorCallback) {
-        UserCache.getEntries(UserCache.MESSAGE_TYPE, key, successCallback, errorCallback);
+    getAllMessagesForInterval: function(key) {
+        return UserCache.getMessagesForInterval(key, UserCache.getAllTimeQuery());
     },
-
-    getEntries: function(type, key, successCallback, errorCallback) {
-        UserCache.db().readTransaction(function(tx) {
-            /*
-             * We can have multiple entries for a particular key as the document associated with the key
-             * is updated throughout the day. We should really override as part of the sync. But for now,
-             * will deal with it in the client by retrieving the last entry.
-             */
-            var selQuery = "SELECT "+UserCache.KEY_WRITE_TS+"," + UserCache.KEY_TIMEZONE+","+UserCache.KEY_DATA+
-                " FROM "+UserCache.TABLE_USER_CACHE +
-                " WHERE "+ UserCache.KEY_KEY + " = '" + key + "'" +
-                " AND "+ UserCache.KEY_TYPE + " = '" + type + "'" +
-                " ORDER BY "+UserCache.KEY_WRITE_TS;
-            window.Logger.log(window.Logger.LEVEL_INFO,
-                "About to execute query "+selQuery+" against userCache")
-            tx.executeSql(selQuery,
-                [],
-                function(tx, data) {
-                    var resultList = [];
-                    console.log("Result has "+data.rows.length+" rows");
-                    for (i = 0; i < data.rows.length; i++) {
-                        row = data.rows.item(i)
-                        entry = {};
-                        metadata = {};
-                        metadata.write_ts = row[UserCache.KEY_WRITE_TS];
-                        metadata.tz = row[UserCache.KEY_TIMEZONE];
-                        metadata.write_fmt_time = moment.unix(metadata.write_ts)
-                                                    .tz(metadata.tz)
-                                                    .format("llll");
-                        entry.metadata = metadata;
-                        entry.data = row[UserCache.KEY_DATA];
-                        resultList.push(entry);
-                    }
-                    successCallback(resultList);
-                }, function(tx,error) {
-                    console.log(error);
-                    errorCallback(error);
-                });
+    getSensorDataForInterval: function(key, tq) {
+        /*
+         The tq parameter represents a time query, a json object with the structure
+         {
+              "key": "write_ts",
+              "startTs": <timestamp_in_secs>,
+              "endTs": <timestamp_in_secs>
+         }
+         */
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "getSensorDataForInterval", [key, tq]);
         });
     },
-    // Let's try to use promises this time, instead of using callbacks. Since
-    // we are putting a document, we don't actually need to return anything,
-    // but whatever.
-    putRWDocument: function(key, value) {
-        return UserCache.putEntries(UserCache.RW_DOCUMENT_TYPE, key, [value]);
+
+    getMessagesForInterval: function(key, tq) {
+        /*
+         The tq parameter represents a time query, a json object with the structure
+         {
+              "key": "write_ts",
+              "startTs": <timestamp_in_secs>,
+              "endTs": <timestamp_in_secs>
+         }
+         */
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "getMessagesForInterval", [key, tq]);
+        });
+    },
+
+    getAllTimeQuery: function() {
+        // Using the standard Date instead of moment in order to reduce dependencies
+        return {key: "write_ts", startTs: 0, endTs: Date.now()/1000}
+    },
+
+    getLastMessages: function(key, nEntries) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "getLastMessages", [key, nEntries]);
+        });
+    },
+
+    getLastSensorData: function(key, nEntries) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "getLastSensorData", [key, nEntries]);
+        });
     },
 
     putMessage: function(key, value) {
-        return UserCache.putEntries(UserCache.MESSAGE_TYPE, key, [value]);
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "putMessage", [key, value]);
+        });
     },
 
-    putEntries: function(type, key, valueList) {
-        // We need a new top level promise because UserCache.db().transaction is async!!
+    putRWDocument: function(key, value) {
         return new Promise(function(resolve, reject) {
-            UserCache.db().transaction(function(tx) {
-                var selQuery = "INSERT INTO "+UserCache.TABLE_USER_CACHE+
-                        " ("+UserCache.KEY_WRITE_TS+"," + UserCache.KEY_TIMEZONE + "," +
-                        UserCache.KEY_TYPE + "," + UserCache.KEY_KEY + "," +
-                        UserCache.KEY_DATA + ") VALUES (?, ?, ?, ?, ?)";
-                window.Logger.log(window.Logger.LOG_INFO,
-                    "About to execute query "+selQuery+" against userCache");
-                // If we tried to execute these serially, it is unclear when
-                // all of the values have been stored because there is a
-                // callback for each of them, and we can get callbacks at
-                // various times. So when do we mark the parent promise as
-                // complete?  We can store both success and fail results in
-                // arrays and generate an event when the sum is complete, but
-                // why not just use promises directly instead?
-                var promiseList = valueList.map(function(value, index, array) {
-                    var currPromise = new Promise(function(resolve, reject) {
-                        var currArgs = [moment().unix(),
-                             // Unsure how accurate this is - do we need a native plugin?
-                             moment.tz.guess(),
-                             type, key, value];
-                        window.Logger.log(window.Logger.LOG_INFO,
-                            "About to use args = "+currArgs);
-                        tx.executeSql(selQuery,
-                             // date in milliseconds, converted by division. Trying to
-                             // keep it consistent with native code and to get more
-                             // uniqueness for the log display.
-                            currArgs, 
-                            function(tx, data) {
-                                // We are inserting, so no expected result
-                                // Didn't fail either, so nothing to push into the
-                                // index list
-                                resolve({"index": index, "value": value, "data": data});
-                            }, function(tx, error) {
-                                window.Logger.log(window.Logger.LOG_ERROR,
-                                   "error = "+error);
-                                reject({"index": index, "value": value,
-                                    "error": error});
-                         }); // exec SQL
-                    }); // promise
-                    return currPromise;
-                }); // map
-                resolve(Promise.all(promiseList));
-            }); // transaction
+            exec(resolve, reject, "UserCache", "putRWDocument", [key, value]);
+        });
+    },
+
+    // No putSensorData exposed through javascript since it is not intended for regularly sensed data
+    clearEntries: function() {
+        return UserCache.clearEntries(UserCache.getAllTimeQuery());
+    },
+    invalidateCache: function() {
+        return UserCache.invalidateCache(UserCache.getAllTimeQuery());
+    },
+    clearEntries: function(tq) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "clearEntries", [tq]);
+        });
+    },
+    invalidateCache: function(tq) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "invalidateCache", [tq]);
+        });
+    },
+    // The nuclear option
+    clearAll: function() {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "clearAll");
         });
     }
 }


### PR DESCRIPTION
This fixes #124.
 
Before this, we used to access the usercache in native code using the plugin, and in javascript using a separate sqlite plugin that accessed the same table.

Unfortunately, accessing the same table through two different handlers runs into locking issues. We unify all access through the usercache plugin to avoid that. It also avoids leaking information such as the table name and table column names outside the native code and make this a lot more modular.
    
This may also be the cause for #126, and thus, for assorted battery issues that have been reported on iOS.
