### PR TITLE
Minor fixes to the usercache code from testing

### DIFF
--- a/src/android/BuiltinUserCache.java
+++ b/src/android/BuiltinUserCache.java
@@ -130,7 +130,7 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         newValues.put(KEY_TIMEZONE, TimeZone.getDefault().getID());
         newValues.put(KEY_TYPE, type);
         newValues.put(KEY_KEY, key);
-        newValues.put(KEY_DATA, new Gson().toJson(value));
+        newValues.put(KEY_DATA, value);
         db.insert(TABLE_USER_CACHE, null, newValues);
         Log.d(cachedCtx, TAG, "Added value for key " + key +
                 " at time "+newValues.getAsDouble(KEY_WRITE_TS));

--- a/src/android/UserCachePlugin.java
+++ b/src/android/UserCachePlugin.java
@@ -107,7 +107,7 @@ public class UserCachePlugin extends CordovaPlugin {
             callbackContext.success();
             return true;
         } else if (action.equals("invalidateCache")) {
-            final JSONObject tqJsonObject = data.getJSONObject(1);
+            final JSONObject tqJsonObject = data.getJSONObject(0);
 
             final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(),
                     UserCache.TimeQuery.class);

--- a/src/ios/BEMBuiltinUserCache.m
+++ b/src/ios/BEMBuiltinUserCache.m
@@ -304,7 +304,7 @@ static BuiltinUserCache *_database;
     NSString* queryString = [NSString
                              stringWithFormat:@"SELECT %@ FROM %@ WHERE %@ = '%@' AND %@ >= %f AND %@ <= %f ORDER BY write_ts DESC",
                              KEY_DATA, TABLE_USER_CACHE, KEY_KEY, key,
-                             tq.timeKey, tq.startTs, tq.timeKey, tq.endTs];
+                             tq.key, tq.startTs, tq.key, tq.endTs];
     NSArray *wrapperJSON = [self readSelectResults:queryString nCols:1];
     return wrapperJSON;
 }
@@ -579,7 +579,7 @@ static BuiltinUserCache *_database;
 
     // Start slightly before and end slightly after to make sure that we get all entries
     TimeQuery* tq = [TimeQuery new];
-    tq.timeKey = KEY_WRITE_TS;
+    tq.key = KEY_WRITE_TS;
     tq.startTs = start_ts - 1;
     tq.endTs = end_ts + 1;
     return tq;
@@ -617,7 +617,7 @@ static BuiltinUserCache *_database;
     [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Clearing entries for timequery %@", tq] showUI:FALSE];
     // Don't delete read-write documents just yet - they will be deleted when we get the overriden document
     NSString* deleteQuery = [NSString stringWithFormat:@"DELETE FROM %@ WHERE (%@ > %f AND %@ < %f AND %@ != '%@')",
-                             TABLE_USER_CACHE, tq.timeKey, tq.startTs, tq.timeKey, tq.endTs, KEY_TYPE, RW_DOCUMENT_TYPE];
+                             TABLE_USER_CACHE, tq.key, tq.startTs, tq.key, tq.endTs, KEY_TYPE, RW_DOCUMENT_TYPE];
     [self clearQuery:deleteQuery];
 }
 
@@ -625,7 +625,7 @@ static BuiltinUserCache *_database;
 {
     // Invalidate the cache, i.e. entries of type DOCUMENT
     NSString* deleteQuery = [NSString stringWithFormat:@"DELETE FROM %@ WHERE (%@ > %f AND %@ < %f AND %@ == '%@')",
-                             TABLE_USER_CACHE, tq.timeKey, tq.startTs, tq.timeKey, tq.endTs, KEY_TYPE, DOCUMENT_TYPE];
+                             TABLE_USER_CACHE, tq.key, tq.startTs, tq.key, tq.endTs, KEY_TYPE, DOCUMENT_TYPE];
     [self clearQuery:deleteQuery];
 }
 

--- a/src/ios/BEMUserCachePlugin.m
+++ b/src/ios/BEMUserCachePlugin.m
@@ -216,6 +216,7 @@
     NSString* callbackId = [command callbackId];
     @try {
         NSDictionary* timequeryDoc = [command.arguments objectAtIndex:0];
+        NSLog(@"timequeryDoc = %@", timequeryDoc);
         TimeQuery* timequery = [TimeQuery new];
         [DataUtils dictToWrapper:timequeryDoc wrapper:timequery];
         [[BuiltinUserCache database] invalidateCache:timequery];

--- a/www/usercache.js
+++ b/www/usercache.js
@@ -99,10 +99,10 @@ var UserCache = {
     },
 
     // No putSensorData exposed through javascript since it is not intended for regularly sensed data
-    clearEntries: function() {
+    clearAllEntries: function() {
         return UserCache.clearEntries(UserCache.getAllTimeQuery());
     },
-    invalidateCache: function() {
+    invalidateAllCache: function() {
         return UserCache.invalidateCache(UserCache.getAllTimeQuery());
     },
     clearEntries: function(tq) {
@@ -118,7 +118,7 @@ var UserCache = {
     // The nuclear option
     clearAll: function() {
         return new Promise(function(resolve, reject) {
-            exec(resolve, reject, "UserCache", "clearAll");
+            exec(resolve, reject, "UserCache", "clearAll", []);
         });
     }
 }


### PR DESCRIPTION
On android:
- while saving values, we get the string directly in putValue, so don't need to convert to string before saving
- in invalidateCache, the 0th argument is the timequery

On iOS
- rename the key field to "key" to be consistent with android and javascript

javascript
- create functions with different names to invalidate all
- fix argument list for `clearAll`