### PR TITLE
Unified usercache fixes

### DIFF
--- a/src/android/BuiltinUserCache.java
+++ b/src/android/BuiltinUserCache.java
@@ -7,7 +7,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -105,6 +104,14 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         return cachedCtx.getString(keyRes);
     }
 
+    private String getSelCols(boolean withMetadata) {
+        if (withMetadata) {
+            return "*";
+        } else {
+            return KEY_DATA;
+        }
+    }
+
     @Override
     public void putSensorData(int keyRes, Object value) {
         putValue(getKey(keyRes), new Gson().toJson(value), SENSOR_DATA_TYPE);
@@ -165,7 +172,7 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
     @Override
     public <T> T getDocument(int keyRes, Class<T> classOfT) {
         String key = getKey(keyRes);
-        String docString = getDocumentString(key);
+        String docString = (String) getDocumentString(key, false);
         if (docString != null) {
             T retVal = new Gson().fromJson(docString, classOfT);
             return retVal;
@@ -174,11 +181,27 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
     }
 
     @Override
-    public String getDocument(String key) throws JSONException {
-        return getDocumentString(key);
+    public Object getDocument(String key, boolean withMetadata)
+            throws JSONException {
+        Object docObj = getDocumentString(key, withMetadata);
+        if (docObj == null) {
+            return new JSONObject();
+        } else {
+            if (withMetadata) {
+                JSONObject entry = (JSONObject)docObj;
+                return entry;
+            } else {
+                try {
+                    return new JSONObject((String) docObj);
+                } catch(JSONException e) {
+                    System.out.println("document was not a JSONObject, trying JSONArray");
+                    return new JSONArray((String)docObj);
+                }
+            }
+        }
     }
 
-    private String getDocumentString(String key) {
+    private Object getDocumentString(String key, boolean withMetadata) {
         // Since we are ordering the results by write_ts, we expect the following behavior:
         // - only RW_DOCUMENT -> it is returned
         // - only DOCUMENT -> it is returned
@@ -190,17 +213,28 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         // to read both values and look at their types
 
         SQLiteDatabase db = this.getReadableDatabase();
-        String selectQuery = "SELECT "+KEY_DATA+" from " + TABLE_USER_CACHE +
+        String selectQuery = "SELECT "+getSelCols(withMetadata)+" from " + TABLE_USER_CACHE +
                 " WHERE " + KEY_KEY + " = '" + key + "'" +
                 " AND ("+ KEY_TYPE + " = '"+ DOCUMENT_TYPE + "' OR " + KEY_TYPE + " = '" + RW_DOCUMENT_TYPE + "')"+
                 " ORDER BY "+KEY_WRITE_TS+" DESC LIMIT 1";
         Cursor queryVal = db.rawQuery(selectQuery, null);
         if (queryVal.moveToFirst()) {
+            if (withMetadata) {
+                try {
+                    return getEntry(queryVal);
+                } catch (JSONException e) {
+                    // We catch and return null instead of throwing because otherwise
+                    // we will need to deal with the JSONException all the way up the getDocument
+                    // with wrapper class chain
+                    return null;
+                }
+            } else {
             String data = queryVal.getString(0);
             System.out.println("data = "+data);
                 String retVal = data;
                 // updateReadTimestamp(key);
             return retVal;
+            }
         } else {
             // If there was no matching entry, return an empty list instead of null
             return null;
@@ -215,40 +249,44 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         return resultArray;
         }
 
-    private JSONArray wrapJson(String[] stringObjects) throws JSONException {
+    private JSONArray wrapJson(Object[] stringOrEntryObjects, boolean withMetadata) throws JSONException {
         JSONArray resultArray = new JSONArray();
-        for (int i=0; i < stringObjects.length; i++) {
-            resultArray.put(new JSONObject(stringObjects[i]));
+        for (int i=0; i < stringOrEntryObjects.length; i++) {
+            JSONObject currEntry = (JSONObject)stringOrEntryObjects[i];
+            if (!withMetadata) {
+                currEntry = new JSONObject((String)stringOrEntryObjects[i]);
+            }
+            resultArray.put(currEntry);
         }
         return resultArray;
     }
 
     @Override
     public <T> T[] getMessagesForInterval(int keyRes, TimeQuery tq, Class<T> classOfT) {
-        return wrapGson(getValuesForInterval(getKey(keyRes), MESSAGE_TYPE, tq), classOfT);
+        return wrapGson((String[])getValuesForInterval(getKey(keyRes), MESSAGE_TYPE, tq, false), classOfT);
     }
 
     @Override
     public <T> T[] getSensorDataForInterval(int keyRes, TimeQuery tq, Class<T> classOfT) {
-        return wrapGson(getValuesForInterval(getKey(keyRes), SENSOR_DATA_TYPE, tq), classOfT);
+        return wrapGson((String[])getValuesForInterval(getKey(keyRes), SENSOR_DATA_TYPE, tq, false), classOfT);
     }
 
     @Override
-    public JSONArray getMessagesForInterval(String key, TimeQuery tq) throws JSONException {
-        return wrapJson(getValuesForInterval(key, MESSAGE_TYPE, tq));
+    public JSONArray getMessagesForInterval(String key, TimeQuery tq, boolean withMetadata) throws JSONException {
+        return wrapJson(getValuesForInterval(key, MESSAGE_TYPE, tq, withMetadata), withMetadata);
     }
 
     @Override
-    public JSONArray getSensorDataForInterval(String key, TimeQuery tq) throws JSONException {
-        return wrapJson(getValuesForInterval(key, SENSOR_DATA_TYPE, tq));
+    public JSONArray getSensorDataForInterval(String key, TimeQuery tq, boolean withMetadata) throws JSONException {
+        return wrapJson(getValuesForInterval(key, SENSOR_DATA_TYPE, tq, withMetadata), withMetadata);
     }
 
-    public String[] getValuesForInterval(String key, String type, TimeQuery tq){
+    public Object[] getValuesForInterval(String key, String type, TimeQuery tq, boolean withMetadata) {
         /*
          * Note: the first getKey(key) is the key of the message (e.g. 'background/location').
          * The second getKey(tq.key) is the key of the time query (e.g. 'write_ts')
          */
-        String queryString = "SELECT "+KEY_DATA+" FROM "+TABLE_USER_CACHE+
+        String queryString = "SELECT "+getSelCols(withMetadata)+" FROM "+TABLE_USER_CACHE+
                 " WHERE "+KEY_KEY+" = '"+ key + "'"+
                 " AND "+KEY_TYPE+" = '" + type + "'" +
                 " AND "+ tq.key +" >= "+tq.startTs+
@@ -258,49 +296,59 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         SQLiteDatabase db = this.getReadableDatabase();
         Cursor resultCursor = db.rawQuery(queryString, null);
 
-        String[] result = getValuesFromCursor(resultCursor);
+        Object[] result = getValuesFromCursor(resultCursor, withMetadata);
         return result;
     }
 
     @Override
     public <T> T[] getLastMessages(int key, int nEntries, Class<T> classOfT) {
-        return wrapGson(getLastValues(getKey(key), MESSAGE_TYPE, nEntries), classOfT);
+        return wrapGson((String[])getLastValues(getKey(key), MESSAGE_TYPE, nEntries, false), classOfT);
     }
 
     @Override
     public <T> T[] getLastSensorData(int key, int nEntries, Class<T> classOfT) {
-        return wrapGson(getLastValues(getKey(key), SENSOR_DATA_TYPE, nEntries), classOfT);
+        return wrapGson((String[])getLastValues(getKey(key), SENSOR_DATA_TYPE, nEntries, false), classOfT);
     }
 
-    public JSONArray getLastMessages(String key, int nEntries) throws JSONException {
-        return wrapJson(getLastValues(key, MESSAGE_TYPE, nEntries));
+    public JSONArray getLastMessages(String key, int nEntries, boolean withMetadata) throws JSONException {
+        return wrapJson(getLastValues(key, MESSAGE_TYPE, nEntries, withMetadata), withMetadata);
     }
 
-    public JSONArray getLastSensorData(String key, int nEntries) throws JSONException {
-        return wrapJson(getLastValues(key, SENSOR_DATA_TYPE, nEntries));
+    public JSONArray getLastSensorData(String key, int nEntries, boolean withMetadata) throws JSONException {
+        return wrapJson(getLastValues(key, SENSOR_DATA_TYPE, nEntries, withMetadata), withMetadata);
     }
 
-    public String[] getLastValues(String key, String type, int nEntries) {
-        String queryString = "SELECT "+KEY_DATA+" FROM "+TABLE_USER_CACHE+
+    public Object[] getLastValues(String key, String type, int nEntries, boolean withMetadata) {
+        String queryString = "SELECT "+getSelCols(withMetadata)+" FROM "+TABLE_USER_CACHE+
                 " WHERE "+KEY_KEY+" = '"+ key + "'"+
                 " AND "+KEY_TYPE+" = '" + type + "'" +
                 " ORDER BY write_ts DESC  LIMIT "+nEntries;
         SQLiteDatabase db = this.getReadableDatabase();
         Cursor resultCursor = db.rawQuery(queryString, null);
 
-        String[] valueList = getValuesFromCursor(resultCursor);
+        Object[] valueList = getValuesFromCursor(resultCursor, withMetadata);
         return valueList;
     }
 
-    private String[] getValuesFromCursor(Cursor resultCursor) {
+    private Object[] getValuesFromCursor(Cursor resultCursor, boolean withMetadata) {
         int resultCount = resultCursor.getCount();
-        String[] resultArray = new String[resultCount];
+        Object[] resultArray = new Object[resultCount];
         // System.out.println("resultArray is " + resultArray);
         if (resultCursor.moveToFirst()) {
             for (int i = 0; i < resultCount; i++) {
+                if (withMetadata) {
+                    try {
+                        JSONObject entry = getEntry(resultCursor);
+                        resultArray[i] = entry;
+                    } catch (JSONException e) {
+                        Log.e(cachedCtx, TAG, "Error " + e + " while converting entry at index " + i
+                                + " to JSON, skipping it");
+                    }
+                } else {
                 String data = resultCursor.getString(0);
                 // System.out.println("data = "+data);
                 resultArray[i] = data;
+                }
                 resultCursor.moveToNext();
             }
         }
@@ -499,6 +547,39 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
     /*
      * Return a string version of the messages and rw documents that need to be sent to the server.
      */
+    private JSONObject getEntry(Cursor queryVal) throws JSONException {
+        Metadata md = new Metadata();
+        md.setWrite_ts(queryVal.getDouble(0));
+        md.setRead_ts(queryVal.getDouble(1));
+        md.setTimeZone(queryVal.getString(2));
+        md.setType(queryVal.getString(3));
+        md.setKey(queryVal.getString(4));
+        md.setPlugin(queryVal.getString(5));
+        String dataStr = queryVal.getString(6);
+        /*
+         * I used to have a GSON wrapper here called "Entry" which encapsulated the metadata
+         * and the data. However, that didn't really work because it was unclear what type
+         * the data was.
+         *
+         * If we assumed that the data was a string, then GSON would escape and encode it
+         * during serialization (e.g. {"data":"{\"mProvider\":\"TEST\",\"mResults\":[0.0,0.0],\"mAccuracy\":5.5,
+         * or {"data":"[\u0027accelerometer\u0027, \u0027gyrometer\u0027, \u0027linear_accelerometer\u0027]
+         * , and expect an encoded string during deserialization.
+         *
+         * This is not consistent with the server, which returns actual JSON in the data, not a string.
+         *
+         * We could attempt to overcome this by assuming that the data is an object, not a string. But in that case,
+         * it is not clear how it would be deserialized, since we wouldn't know what class it was.
+         *
+         * So we are going to return a raw JSON object here instead of a GSONed object. That will also allow us to
+         * put it into the right wrapper object (phone_to_server or server_to_phone).
+         */
+        JSONObject entry = new JSONObject();
+        entry.put(METADATA_TAG, new JSONObject(new Gson().toJson(md)));
+        entry.put(DATA_TAG, new JSONObject(dataStr));
+            // Log.d(cachedCtx, TAG, "For row " + i + ", about to send string " + entry.toString());
+        return entry;
+    }
 
     public JSONArray sync_phone_to_server() {
         double lastTripEndTs = getLastTs();
@@ -530,46 +611,18 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         // in which case we return the empty JSONArray, to be consistent.
         if (queryVal.moveToFirst()) {
             for (int i = 0; i < resultCount; i++) {
-                Metadata md = new Metadata();
-                md.setWrite_ts(queryVal.getDouble(0));
-                md.setRead_ts(queryVal.getDouble(1));
-                md.setTimeZone(queryVal.getString(2));
-                md.setType(queryVal.getString(3));
-                md.setKey(queryVal.getString(4));
-                md.setPlugin(queryVal.getString(5));
-                String dataStr = queryVal.getString(6);
+                try {
+                    JSONObject entry = getEntry(queryVal);
+                    JSONObject md = entry.getJSONObject(METADATA_TAG);
                 if (i % 500 == 0) {
-                    Log.d(cachedCtx, TAG, "Reading entry = " + i+" with key "+md.getKey()
-                            + " and write_ts "+md.getWrite_ts());
+                        Log.d(cachedCtx, TAG, "Reading entry = " + i+" with key "+md.getString("key")
+                                + " and write_ts "+md.getDouble("write_ts"));
                 }
 
-                /*
-                 * I used to have a GSON wrapper here called "Entry" which encapsulated the metadata
-                 * and the data. However, that didn't really work because it was unclear what type
-                 * the data was.
-                 *
-                 * If we assumed that the data was a string, then GSON would escape and encode it
-                 * during serialization (e.g. {"data":"{\"mProvider\":\"TEST\",\"mResults\":[0.0,0.0],\"mAccuracy\":5.5,
-                 * or {"data":"[\u0027accelerometer\u0027, \u0027gyrometer\u0027, \u0027linear_accelerometer\u0027]
-                 * , and expect an encoded string during deserialization.
-                 *
-                 * This is not consistent with the server, which returns actual JSON in the data, not a string.
-                 *
-                 * We could attempt to overcome this by assuming that the data is an object, not a string. But in that case,
-                 * it is not clear how it would be deserialized, since we wouldn't know what class it was.
-                 *
-                 * So we are going to return a raw JSON object here instead of a GSONed object. That will also allow us to
-                 * put it into the right wrapper object (phone_to_server or server_to_phone).
-                 */
-                try {
-                JSONObject entry = new JSONObject();
-                entry.put(METADATA_TAG, new JSONObject(new Gson().toJson(md)));
-                entry.put(DATA_TAG, new JSONObject(dataStr));
-                // Log.d(cachedCtx, TAG, "For row " + i + ", about to send string " + entry.toString());
                 entryArray.put(entry);
                 queryVal.moveToNext();
                 } catch (JSONException e) {
-                    Log.e(cachedCtx, TAG, "Error " + e + " while converting data string " + dataStr + " to JSON, skipping it");
+                    Log.e(cachedCtx, TAG, "Error " + e + " while converting data string " + queryVal.getString(6) + " to JSON, skipping it");
                     // TODO: Re-enable once we resolve
                     // https://github.com/e-mission/cordova-usercache/issues/7
                     // putErrorValue(md, dataStr);

--- a/src/android/BuiltinUserCache.java
+++ b/src/android/BuiltinUserCache.java
@@ -402,9 +402,9 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
             String currKey = (String)rwKeys[i];
             String rwDocDeleteWhereQuery = KEY_TYPE+
                     " = '"+RW_DOCUMENT_TYPE+"' AND "+KEY_WRITE_TS+
-                    " < (SELECT MAX("+KEY_WRITE_TS+") FROM "+
+                    " < MIN("+(long)tq.getEndTs()+", (SELECT MAX("+KEY_WRITE_TS+") FROM "+
                     TABLE_USER_CACHE + " WHERE (" + KEY_KEY+" = '"+currKey+"' AND "+
-                    KEY_TYPE+" = '"+RW_DOCUMENT_TYPE+"'))";
+                    KEY_TYPE+" = '"+RW_DOCUMENT_TYPE+"')))";
             Log.d(cachedCtx, TAG, "Clearing obsolete RW-DOCUMENTS using "+rwDocDeleteWhereQuery);
             int delEntries = db.delete(TABLE_USER_CACHE, rwDocDeleteWhereQuery, null);
             Log.i(cachedCtx, TAG, "Deleted " + delEntries + " rw-document entries");

--- a/src/android/UserCache.java
+++ b/src/android/UserCache.java
@@ -78,11 +78,15 @@ public interface UserCache {
     // a) cumbersome and
     // b) not necessary when the objects are not consumed in native code
     // c) wasted cycles JSON -> GSON -> JSON
-    public abstract JSONArray getMessagesForInterval(String key, TimeQuery tq) throws JSONException;
-    public abstract JSONArray getSensorDataForInterval(String key, TimeQuery tq) throws JSONException;
+    public abstract JSONArray getMessagesForInterval(String key, TimeQuery tq,
+                                                     boolean withMetadata) throws JSONException;
+    public abstract JSONArray getSensorDataForInterval(String key, TimeQuery tq,
+                                                       boolean withMetadata) throws JSONException;
 
-    public abstract JSONArray getLastMessages(String key, int nEntries) throws JSONException;
-    public abstract JSONArray getLastSensorData(String key, int nEntries) throws JSONException;
+    public abstract JSONArray getLastMessages(String key, int nEntries,
+                                              boolean withMetadata) throws JSONException;
+    public abstract JSONArray getLastSensorData(String key, int nEntries,
+                                                boolean withMetadata) throws JSONException;
 
         /**
          * Return the document that matches the specified key.
@@ -92,7 +96,7 @@ public interface UserCache {
     public abstract <T> T getDocument(int key, Class<T> classOfT);
     // Can be either JSONObject or JSONArray, and they don't have a common superclass other than
     // object
-    public abstract String getDocument(String key) throws JSONException;
+    public abstract Object getDocument(String key, boolean withMetadata) throws JSONException;
 
     /**
      * Delete documents that match the specified time query.

--- a/src/android/UserCachePlugin.java
+++ b/src/android/UserCachePlugin.java
@@ -34,50 +34,47 @@ public class UserCachePlugin extends CordovaPlugin {
         Context ctxt = cordova.getActivity();
         if (action.equals("getDocument")) {
             final String documentKey = data.getString(0);
-            String docStr = UserCacheFactory.getUserCache(ctxt).getDocument(documentKey);
-            if (docStr == null) {
-                // Cordova doesn't like us to return with an empty objectA
-                // because then we get an NPE while initializing the result
-                // https://github.com/apache/cordova-android/blob/457c5b8b3b694265c991b456b15015741ade5014/framework/src/org/apache/cordova/PluginResult.java#L52
-                callbackContext.success(new JSONObject());
-            } else {
+            final boolean withMetadata = data.getBoolean(1);
+            Object retVal = UserCacheFactory.getUserCache(ctxt).getDocument(documentKey, withMetadata);
                 try {
-                    callbackContext.success(new JSONObject(docStr));
-                } catch (JSONException e) {
-                    System.out.println("document was not a JSONObject, trying JSONArray");
-                    callbackContext.success(new JSONArray(docStr));
-                }
+                callbackContext.success((JSONObject) retVal);
+            } catch (ClassCastException e) {
+                callbackContext.success((JSONArray) retVal);
             }
             return true;
         } else if (action.equals("getSensorDataForInterval")) {
             final String key = data.getString(0);
             final JSONObject tqJsonObject = data.getJSONObject(1);
+            final boolean withMetadata = data.getBoolean(2);
             final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(), UserCache.TimeQuery.class);
             JSONArray result = UserCacheFactory.getUserCache(ctxt)
-                    .getSensorDataForInterval(key, timeQuery);
+                    .getSensorDataForInterval(key, timeQuery, withMetadata);
             callbackContext.success(result);
             return true;
         } else if (action.equals("getMessagesForInterval")) {
             final String key = data.getString(0);
             final JSONObject tqJsonObject = data.getJSONObject(1);
+            final boolean withMetadata = data.getBoolean(2);
             final UserCache.TimeQuery timeQuery = new Gson().fromJson(tqJsonObject.toString(),
                     UserCache.TimeQuery.class);
             JSONArray result = UserCacheFactory.getUserCache(ctxt)
-                    .getMessagesForInterval(key, timeQuery);
+                    .getMessagesForInterval(key, timeQuery, withMetadata);
             callbackContext.success(result);
             return true;
         } else if (action.equals("getLastMessages")) {
             final String key = data.getString(0);
             final int nEntries = data.getInt(1);
+            final boolean withMetadata = data.getBoolean(2);
             JSONArray result = UserCacheFactory.getUserCache(ctxt)
-                    .getLastMessages(key, nEntries);
+                    .getLastMessages(key, nEntries, withMetadata);
             callbackContext.success(result);
             return true;
         } else if (action.equals("getLastSensorData")) {
             final String key = data.getString(0);
             final int nEntries = data.getInt(1);
+            final boolean withMetadata = data.getBoolean(2);
             JSONArray result = UserCacheFactory.getUserCache(ctxt)
-                    .getLastSensorData(key, nEntries);
+                    .getLastSensorData(key, nEntries, withMetadata);
             callbackContext.success(result);
             return true;
         } else if (action.equals("putMessage")) {

--- a/src/ios/BEMBuiltinUserCache.h
+++ b/src/ios/BEMBuiltinUserCache.h
@@ -46,12 +46,13 @@
 
 // Versions that return JSON, for use with the plugin interface
 
-- (NSArray*) getSensorDataForInterval:(NSString*) key tq:(TimeQuery*)tq;
-- (NSArray*) getLastSensorData:(NSString*) key nEntries:(int)nEntries;
+- (NSArray*) getSensorDataForInterval:(NSString*) key tq:(TimeQuery*)tq withMetadata:(BOOL)withMetadata;
+- (NSArray*) getLastSensorData:(NSString*) key nEntries:(int)nEntries withMetadata:(BOOL)withMetadata;
 
-- (NSArray*) getMessageForInterval:(NSString*) key tq:(TimeQuery*)tq;
-- (NSArray*) getLastMessage:(NSString*) key nEntries:(int)nEntries;
-- (NSDictionary*) getDocument:(NSString*)key;
+- (NSArray*) getMessageForInterval:(NSString*) key tq:(TimeQuery*)tq withMetadata:(BOOL)withMetadata;
+- (NSArray*) getLastMessage:(NSString*) key nEntries:(int)nEntries withMetadata:(BOOL)withMetadata;
+
+- (NSDictionary*) getDocument:(NSString*)key withMetadata:(BOOL)withMetadata;
 
 - (double) getTsOfLastTransition;
 - (NSArray*) syncPhoneToServer;

--- a/src/ios/BEMBuiltinUserCache.h
+++ b/src/ios/BEMBuiltinUserCache.h
@@ -63,6 +63,9 @@
 + (NSDate*) getWriteTs:(NSDictionary*)entry;
 
 - (void) clearEntries:(TimeQuery*)tq;
+- (void) clearSupersededRWDocs:(TimeQuery*)tq;
+- (void) clearObsoleteDocs:(TimeQuery*)tq;
+- (void) checkAfterPull;
 - (void) invalidateCache:(TimeQuery*)tq;
 - (void) clear;
 @end

--- a/src/ios/BEMBuiltinUserCache.m
+++ b/src/ios/BEMBuiltinUserCache.m
@@ -657,9 +657,9 @@ static BuiltinUserCache *_database;
     for (int i=0; i < docResults.count; i++) {
         NSString* currKey = docResults[i];
         // DELETE FROM TABLE_USER_CACHE WHERE type = 'rw-document) AND
-        // write_ts < (SELECT MAX(write_ts) FROM userCache WHERE (key = '...' AND TYPE = 'rw-document'))
-        NSString* rwDocDeleteQuery = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@ = '%@' AND %@ < (SELECT MAX(%@) FROM %@ WHERE (%@ = '%@' AND %@ = '%@'))",
-                                      TABLE_USER_CACHE, KEY_TYPE, RW_DOCUMENT_TYPE, KEY_WRITE_TS, KEY_WRITE_TS, TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE];
+        // write_ts < MIN(tq.endTs, (SELECT MAX(write_ts) FROM userCache WHERE (key = '...' AND TYPE = 'rw-document')))
+        NSString* rwDocDeleteQuery = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@ = '%@' AND %@ < MIN(%.0f, (SELECT MAX(%@) FROM %@ WHERE (%@ = '%@' AND %@ = '%@')))",
+                                      TABLE_USER_CACHE, KEY_TYPE, RW_DOCUMENT_TYPE, KEY_WRITE_TS, tq.endTs, KEY_WRITE_TS, TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE];
     [LocalNotificationManager addNotification:[NSString stringWithFormat:@"rwDocDeleteQuery = %@", rwDocDeleteQuery] showUI:FALSE];
     [self clearQuery:rwDocDeleteQuery];
     }

--- a/src/ios/BEMUserCachePlugin.m
+++ b/src/ios/BEMUserCachePlugin.m
@@ -211,7 +211,13 @@
         NSDictionary* timequeryDoc = [command.arguments objectAtIndex:0];
         TimeQuery* timequery = [TimeQuery new];
         [DataUtils dictToWrapper:timequeryDoc wrapper:timequery];
+        // Clearing is now split up, but let's not bloat up the
+        // interface further. It is unclear when this will be
+        // ever called from the UI anyway, but let us just clear
+        // all three types of messages from the phone anyway
         [[BuiltinUserCache database] clearEntries:timequery];
+        [[BuiltinUserCache database] clearSupersededRWDocs:timequery];
+        [[BuiltinUserCache database] clearObsoleteDocs:timequery];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];

--- a/src/ios/BEMUserCachePlugin.m
+++ b/src/ios/BEMUserCachePlugin.m
@@ -18,7 +18,9 @@
     NSString* callbackId = [command callbackId];
     @try {
         NSString* key = [[command arguments] objectAtIndex:0];
-        NSDictionary* resultDoc = [[BuiltinUserCache database] getDocument:key];
+        BOOL withMetadata = [[[command arguments] objectAtIndex:1] boolValue];
+        NSDictionary* resultDoc = [[BuiltinUserCache database] getDocument:key
+                                                              withMetadata:withMetadata];
         if (resultDoc == NULL) {
             resultDoc = [NSDictionary new];
         }
@@ -44,7 +46,10 @@
         NSDictionary* timequeryDoc = [command.arguments objectAtIndex:1];
         TimeQuery* timequery = [TimeQuery new];
         [DataUtils dictToWrapper:timequeryDoc wrapper:timequery];
-        NSArray* resultDoc = [[BuiltinUserCache database] getSensorDataForInterval:key tq:timequery];
+        BOOL withMetadata = [[[command arguments] objectAtIndex:2] boolValue];
+        NSArray* resultDoc = [[BuiltinUserCache database] getSensorDataForInterval:key
+                                                                                tq:timequery
+                                                                      withMetadata:withMetadata];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK
                                    messageAsArray:resultDoc];
@@ -67,7 +72,10 @@
         NSDictionary* timequeryDoc = [command.arguments objectAtIndex:1];
         TimeQuery* timequery = [TimeQuery new];
         [DataUtils dictToWrapper:timequeryDoc wrapper:timequery];
-        NSArray* resultDoc = [[BuiltinUserCache database] getMessageForInterval:key tq:timequery];
+        BOOL withMetadata = [[[command arguments] objectAtIndex:2] boolValue];
+        NSArray* resultDoc = [[BuiltinUserCache database] getMessageForInterval:key
+                                                                             tq:timequery
+                                                                   withMetadata:withMetadata];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK
                                    messageAsArray:resultDoc];
@@ -90,7 +98,10 @@
         NSString* key = [[command arguments] objectAtIndex:0];
         NSString* nEntriesStr = [command.arguments objectAtIndex:1];
         int nEntries = [nEntriesStr intValue];
-        NSArray* resultDoc = [[BuiltinUserCache database] getLastMessage:key nEntries:nEntries];
+        BOOL withMetadata = [[[command arguments] objectAtIndex:2] boolValue];
+        NSArray* resultDoc = [[BuiltinUserCache database] getLastMessage:key
+                                                                nEntries:nEntries
+                                                            withMetadata:withMetadata];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK
                                    messageAsArray:resultDoc];
@@ -112,7 +123,10 @@
         NSString* key = [[command arguments] objectAtIndex:0];
         NSString* nEntriesStr = [command.arguments objectAtIndex:1];
         int nEntries = [nEntriesStr intValue];
-        NSArray* resultDoc = [[BuiltinUserCache database] getLastMessage:key nEntries:nEntries];
+        BOOL withMetadata = [[[command arguments] objectAtIndex:2] boolValue];
+        NSArray* resultDoc = [[BuiltinUserCache database] getLastMessage:key
+                                                                nEntries:nEntries
+                                                            withMetadata:withMetadata];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK
                                    messageAsArray:resultDoc];

--- a/www/usercache.js
+++ b/www/usercache.js
@@ -19,9 +19,9 @@ var UserCache = {
     DOCUMENT_TYPE: "document",
     RW_DOCUMENT_TYPE: "rw-document",
 
-    getDocument: function(key) {
+    getDocument: function(key, withMetadata) {
         return new Promise (function(resolve, reject){
-            exec(resolve, reject, "UserCache", "getDocument", [key])
+            exec(resolve, reject, "UserCache", "getDocument", [key, withMetadata])
         });
     },
 
@@ -36,12 +36,12 @@ var UserCache = {
     },
 
     getAllSensorData: function(key) {
-        return UserCache.getSensorDataForInterval(key, UserCache.getAllTimeQuery());
+        return UserCache.getSensorDataForInterval(key, UserCache.getAllTimeQuery(), true);
     },
     getAllMessages: function(key) {
-        return UserCache.getMessagesForInterval(key, UserCache.getAllTimeQuery());
+        return UserCache.getMessagesForInterval(key, UserCache.getAllTimeQuery(), true);
     },
-    getSensorDataForInterval: function(key, tq) {
+    getSensorDataForInterval: function(key, tq, withMetadata) {
         /*
          The tq parameter represents a time query, a json object with the structure
          {
@@ -51,11 +51,11 @@ var UserCache = {
          }
          */
         return new Promise(function(resolve, reject) {
-            exec(resolve, reject, "UserCache", "getSensorDataForInterval", [key, tq]);
+            exec(resolve, reject, "UserCache", "getSensorDataForInterval", [key, tq, withMetadata]);
         });
     },
 
-    getMessagesForInterval: function(key, tq) {
+    getMessagesForInterval: function(key, tq, withMetadata) {
         /*
          The tq parameter represents a time query, a json object with the structure
          {
@@ -65,7 +65,7 @@ var UserCache = {
          }
          */
         return new Promise(function(resolve, reject) {
-            exec(resolve, reject, "UserCache", "getMessagesForInterval", [key, tq]);
+            exec(resolve, reject, "UserCache", "getMessagesForInterval", [key, tq, withMetadata]);
         });
     },
 
@@ -74,15 +74,15 @@ var UserCache = {
         return {key: "write_ts", startTs: 0, endTs: Date.now()/1000}
     },
 
-    getLastMessages: function(key, nEntries) {
+    getLastMessages: function(key, nEntries, withMetadata) {
         return new Promise(function(resolve, reject) {
-            exec(resolve, reject, "UserCache", "getLastMessages", [key, nEntries]);
+            exec(resolve, reject, "UserCache", "getLastMessages", [key, nEntries, withMetadata]);
         });
     },
 
-    getLastSensorData: function(key, nEntries) {
+    getLastSensorData: function(key, nEntries, withMetadata) {
         return new Promise(function(resolve, reject) {
-            exec(resolve, reject, "UserCache", "getLastSensorData", [key, nEntries]);
+            exec(resolve, reject, "UserCache", "getLastSensorData", [key, nEntries, withMetadata]);
         });
     },
 


### PR DESCRIPTION
- Extend the unified usercache information to return both data and metadata (fixes the regression in showing the sensor data from the Profile screen)
- Delete obsolete documents from the usercache
    - The naive implementation introduced an issue with the consent
    - Fixed that by splitting the clean functions
    - while fixing that, also actually deleted rw documents on android (see #13)