### PR TITLE
Switch all the user stats to the user cache

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,7 @@
     <source-file src="src/android/BuiltinUserCache.java" target-dir="src/edu/berkeley/eecs/emission/cordova/usercache"/>
     <source-file src="src/android/UserCachePlugin.java" target-dir="src/edu/berkeley/eecs/emission/cordova/usercache"/>
     <resource-file src="res/android/usercachekeys.xml" target="res/values/usercachekeys.xml"/>
+    <resource-file src="res/android/app_stats.xml" target="res/values/usercachekeys.xml"/>
   </platform>
 
   <platform name="ios">
@@ -49,5 +50,6 @@
     <source-file src="src/ios/BEMUserCachePlugin.m"/>
     <resource-file src="src/ios/userCacheDB"/>
     <resource-file src="res/ios/usercachekeys.plist"/>
+    <resource-file src="res/ios/app_stats.plist"/>
   </platform>
 </plugin>

--- a/res/android/app_stats.xml
+++ b/res/android/app_stats.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_launched">app_launched</string>
+    <string name="sync_launched">sync_launched</string>
+    <string name="sync_push_list_size">sync_push_list_size</string>
+    <string name="sync_pull_list_size">sync_pull_list_size</string>
+    <string name="sync_duration">sync_duration</string>
+    <string name="pull_duration">pull_duration</string>
+    <string name="push_duration">push_duration</string>
+</resources>

--- a/res/android/usercachekeys.xml
+++ b/res/android/usercachekeys.xml
@@ -9,5 +9,8 @@
     <string name="key.usercache.sync_config">config/sync_config</string>
     <string name="key.usercache.consent_config">config/consent</string>
     <string name="key.usercache.transition">statemachine/transition</string>
+    <string name="key.usercache.client_time">stats/client_time</string>
+    <string name="key.usercache.client_nav_event">stats/client_nav_event</string>
+    <string name="key.usercache.client_error">stats/client_error</string>
     <string name="metadata.usercache.write_ts">write_ts</string>
 </resources>

--- a/res/ios/app_stats.plist
+++ b/res/ios/app_stats.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>app_launched</key>
+	<string>app_launched</string>
+	<key>sync_push_list_size</key>
+	<string>sync_push_list_size</string>
+	<key>sync_pull_list_size</key>
+	<string>sync_pull_list_size</string>
+	<key>sync_duration</key>
+	<string>sync_duration</string>
+	<key>pull_duration</key>
+	<string>pull_duration</string>
+	<key>push_duration</key>
+	<string>push_duration</string>
+</dict>
+</plist>

--- a/res/ios/usercachekeys.plist
+++ b/res/ios/usercachekeys.plist
@@ -12,14 +12,20 @@
 	<string>background/accelerometer</string>
 	<key>key.usercache.battery</key>
 	<string>background/battery</string>
-    <key>key.usercache.sensor_config</key>
-    <string>config/sensor_config</string>
-    <key>key.usercache.sync_config</key>
-    <string>config/sync_config</string>
-    <key>key.usercache.consent_config</key>
-    <string>config/consent</string>
+	<key>key.usercache.sensor_config</key>
+	<string>config/sensor_config</string>
+	<key>key.usercache.sync_config</key>
+	<string>config/sync_config</string>
+	<key>key.usercache.consent_config</key>
+	<string>config/consent</string>
 	<key>key.usercache.transition</key>
 	<string>statemachine/transition</string>
+	<key>key.usercache.client_time</key>
+	<string>stats/client_time</string>
+	<key>key.usercache.client_nav_event</key>
+	<string>stats/client_nav_event</string>
+	<key>key.usercache.client_error</key>
+	<string>stats/client_error</string>
 	<key>metadata.usercache.write_ts</key>
 	<string>write_ts</string>
 </dict>

--- a/src/ios/BEMBuiltinUserCache.m
+++ b/src/ios/BEMBuiltinUserCache.m
@@ -104,7 +104,7 @@ static BuiltinUserCache *_database;
 - (NSString*)getStatName:(NSString*)label {
     NSString* statName = [statsNamesDict objectForKey:label];
     if (statName == NULL) {
-        [NSException raise:@"unknown stat" format:@"stat %@ not defined in app_stats plist", label];
+        [NSException raise:@"unknown stat" format:@"stat %@ not defined in usercache plist", label];
     }
     return statName;
 }


### PR DESCRIPTION
Back when we stored the raw data directly as sections and trips, we used to
store the stats in a timeseries. Now that we are storing the raw data in a
timeseries, and are planning to use the stats for analysis into user behavior,
it would be more convenient to store the stats into the same timeseries. Then,
the timeseries is really the a full representation of the source of truth, we
can reuse similar code for analysis.

This change has several components.
- In the usercache, since we already have the functionality, we just need to add a new set of keys.
  We also need to move the app_stats keys to this repo since we are going to
  delete the entire old client stats repo. Woo!!
- Add a new wrapper for a stats event since we need to send that to the server
- Currently, the only client stats that we report from native code are in the
  sync code path. Change all of those to use usercache stats.
- Move the app_launched stat to the data collection plugin load
- From the `CommunicationHelper`, remove all instances of the `setStats` call

The related server commit is https://github.com/e-mission/e-mission-server/commit/7487c82578e8933f4da8f9d3fa3522c102906c81
from pull request https://github.com/e-mission/e-mission-server/pull/443