### PR TITLE
Minor usercache fixes found in testing

### DIFF
--- a/res/ios/app_stats.plist
+++ b/res/ios/app_stats.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>app_launched</key>
 	<string>app_launched</string>
+	<key>sync_launched</key>
+	<string>sync_launched</string>
 	<key>sync_push_list_size</key>
 	<string>sync_push_list_size</string>
 	<key>sync_pull_list_size</key>

--- a/src/ios/BEMUserCachePlugin.m
+++ b/src/ios/BEMUserCachePlugin.m
@@ -148,7 +148,7 @@
         NSString* key = [[command arguments] objectAtIndex:0];
         NSDictionary* value = [command.arguments objectAtIndex:1];
 
-        [[BuiltinUserCache database] putMessage:key value:value];
+        [[BuiltinUserCache database] putMessage:key jsonValue:value];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];
@@ -169,7 +169,7 @@
         NSString* key = [[command arguments] objectAtIndex:0];
         NSDictionary* value = [command.arguments objectAtIndex:1];
         
-        [[BuiltinUserCache database] putReadWriteDocument:key value:value];
+        [[BuiltinUserCache database] putReadWriteDocument:key jsonValue:value];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];
@@ -190,7 +190,7 @@
         NSString* key = [[command arguments] objectAtIndex:0];
         NSDictionary* value = [command.arguments objectAtIndex:1];
         
-        [[BuiltinUserCache database] putSensorData:key value:value];
+        [[BuiltinUserCache database] putSensorData:key jsonValue:value];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];


### PR DESCRIPTION
- Ensure that there is a key corresponding to sync_launched
- Ensure that the plugin calls the external JSON-ified interface instead of the
  internal one that expects a wrapper class

Tested on both iOS and android