### PR TITLE
Ensure that there is a rw-document corresponding to every config docu…

### DIFF
--- a/src/ios/BEMBuiltinUserCache.m
+++ b/src/ios/BEMBuiltinUserCache.m
@@ -665,12 +665,47 @@ static BuiltinUserCache *_database;
     }
 }
 
+/*
+ * Hack to ensure that we have an rw-document that cannot be deleted for every config. This should make existing installs become 
+ * similar to new installs and ensure that https://github.com/e-mission/cordova-jwt-auth/issues/8#issuecomment-260214971 does
+ * not recur.
+ *
+ * Therefore, it is sufficient to handle the existing possible config documents. This can be deleted after everybody has upgraded
+ * to the most recent version.
+ */
+
+- (void) convertConfigToRW:(TimeQuery*) tq {
+    NSArray* configKeys = @[@"config/consent", @"config/sync_config", @"config/sensor_config"];
+    for (int i = 0; i < configKeys.count; i++) {
+        NSString* currKey = configKeys[i];
+        [LocalNotificationManager addNotification:[NSString stringWithFormat:@"About to check rw state for config %@", currKey]];
+        // SELECT DATA FROM userCache WHERE KEY = currKey and TYPE = 'rw-document';
+        NSString* currQuery = [NSString stringWithFormat:@"SELECT * FROM %@ WHERE %@ = '%@' AND %@ = '%@'",
+                               TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, @"rw-document"];
+        NSArray* checkResults = [self readSelectResults:currQuery withMetadata:YES];
+        if ([checkResults count] > 0) {
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Already have rw-document for key %@, nothing to fix", currKey]];
+        } else {
+            NSDictionary* currDoc = [self getDocument:currKey withMetadata:YES];
+            if (currDoc == NULL) {
+                [LocalNotificationManager addNotification:[NSString stringWithFormat:@"For key %@, found no document found either, skipping", currKey]];
+            } else {
+                [LocalNotificationManager addNotification:[NSString stringWithFormat:@"For key %@, found document with write_ts = %@, but not rw-document, changing...", currDoc[@"metadata"][@"write_ts"], currKey]];
+                [self putReadWriteDocument:currKey jsonValue:currDoc[KEY_DATA]];
+                // I could try to update the rw-document here to match the original write_ts, but then I'd have to write another SQL
+                // statement, adding complexity to what it essentially a one-time hack. I also don't remember whether the write_ts
+                // from the server was the same as the write_ts of the original rw-document. Let's just stick with this for now...
+            }
+        }
+    }
+}
+
 - (void) clearObsoleteDocs:(TimeQuery*)tq {
     // Now, clear all documents. If the documents are still valid, they will be
     // pulled from the server. If they are not, they should be cleared up so that
     // we don't grow forever.
     // See https://github.com/e-mission/cordova-usercache/issues/24
-    
+    [self convertConfigToRW:tq];
     NSString* deleteDocQuery = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@ = '%@'",
                                 TABLE_USER_CACHE, KEY_TYPE, DOCUMENT_TYPE];
     [LocalNotificationManager addNotification:[NSString stringWithFormat:@"deleteDocQuery = %@", deleteDocQuery] showUI:FALSE];

--- a/src/ios/BEMBuiltinUserCache.m
+++ b/src/ios/BEMBuiltinUserCache.m
@@ -656,6 +656,13 @@ static BuiltinUserCache *_database;
     NSArray* docResults = [self readSelectResults:checkQuery withMetadata:NO];
     for (int i=0; i < docResults.count; i++) {
         NSString* currKey = docResults[i];
+        NSString* selectQuery = [NSString stringWithFormat:@"SELECT * FROM %@ WHERE %@ = '%@' AND %@ < MIN(%.0f, (SELECT MAX(%@) FROM %@ WHERE (%@ = '%@' AND %@ = '%@')))",
+                                 TABLE_USER_CACHE, KEY_TYPE, RW_DOCUMENT_TYPE, KEY_WRITE_TS, tq.endTs, KEY_WRITE_TS, TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE];
+        [LocalNotificationManager addNotification:[NSString stringWithFormat:@"selectQuery = %@", selectQuery] showUI:FALSE];
+        NSArray* toDeleteDocs = [self readSelectResults:selectQuery withMetadata:YES];
+        for (int j = 0; j < toDeleteDocs.count; j++) {
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:@"At index %d, about to delete = %@", j, toDeleteDocs[j]] showUI:FALSE];
+        }
         // DELETE FROM TABLE_USER_CACHE WHERE type = 'rw-document) AND
         // write_ts < MIN(tq.endTs, (SELECT MAX(write_ts) FROM userCache WHERE (key = '...' AND TYPE = 'rw-document')))
         NSString* rwDocDeleteQuery = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@ = '%@' AND %@ < MIN(%.0f, (SELECT MAX(%@) FROM %@ WHERE (%@ = '%@' AND %@ = '%@')))",


### PR DESCRIPTION
…ment

This is a hack to address the issue of consent/other configs getting deleted if
they are only stored as documents. Prior to
https://github.com/shankari/cordova-usercache/commit/f35f39a1766ee660519a7481eb05c8ac7d8be43b,
we used to delete the rw-document for config objects after we had pulled the
appropriate document. At that time, we also deleted all entries, not just the
ones in the current time query, to ensure that we didn't have an infinitely
growing cache (https://github.com/e-mission/cordova-usercache/issues/24).

But now, we can have a situation in which all the documents are deleted, and
then the app is terminated during the sync, so that the newly retrieved
document is never saved to the cache. Then, we detect consent = false, for
example, and turn off data collection.

This won't happen for installations after
https://github.com/shankari/cordova-usercache/commit/f35f39a1766ee660519a7481eb05c8ac7d8be43b
since they will retain the last rw-document, but for prior installations, the
only config is in the document (https://github.com/e-mission/cordova-jwt-auth/issues/8#issuecomment-260214971)

So, as described in
https://github.com/e-mission/cordova-jwt-auth/issues/8#issuecomment-260219925
we introduce a hack that will copy document-only configs to a rw-document so
that the two use cases will be unified.

TESTING DONE:

- `rw-document` = 1, `document` = 1
    ```
    2016-11-14 05:58:25.534 emission[1452:1472530] About to check rw state for config config/consent
    2016-11-14 05:58:25.556 emission[1452:1472530] Already have rw-document for key config/consent, nothing to fix
    ```

- `rw-document = 0, `document` = 1
    ```
    2016-11-14 05:58:25.570 emission[1452:1472530] About to check rw state for config config/sync_config
    2016-11-14 05:58:25.586 emission[1452:1472530] For key 1476834909.464491, found document with write_ts = config/sync_config, but not rw-document, changing...
    2016-11-14 05:58:25.602 emission[1452:1472530] data has 49 bytes, str has size 49

    2016-11-14 05:58:25.618 emission[1452:1472530] About to check rw state for config config/sensor_config
    2016-11-14 05:58:25.631 emission[1452:1472530] For key 1478276420.88226, found document with write_ts = config/sensor_config, but not rw-document, changing...
    2016-11-14 05:58:25.642 emission[1452:1472530] data has 308 bytes, str has size 308
    ```

- `rw-document` = 0, `document` = 0

```
2016-11-14 06:09:23.243 emission[1452:1472530] About to check rw state for config config/consent
2016-11-14 06:09:23.259 emission[1452:1472530] For key config/consent, found no document found either, skipping

2016-11-14 06:09:23.274 emission[1452:1472530] About to check rw state for config config/sync_config
2016-11-14 06:09:23.292 emission[1452:1472530] For key config/sync_config, found no document found either, skipping

2016-11-14 06:09:23.308 emission[1452:1472530] About to check rw state for config config/sensor_config
2016-11-14 06:09:23.323 emission[1452:1472530] For key config/sensor_config, found no document found either, skipping
```

- `rw-document` = 1, `document` = 0

```
2016-11-14 06:14:43.735 emission[1452:1472530] About to check rw state for config config/consent
2016-11-14 06:14:43.753 emission[1452:1472530] Already have rw-document for key config/consent, nothing to fix

2016-11-14 06:14:43.770 emission[1452:1472530] About to check rw state for config config/sync_config
2016-11-14 06:14:43.784 emission[1452:1472530] For key config/sync_config, found no document found either, skipping

2016-11-14 06:14:43.797 emission[1452:1472530] About to check rw state for config config/sensor_config
2016-11-14 06:14:43.815 emission[1452:1472530] For key config/sensor_config, found no document found either, skipping
```

- `rw-document` = 0, `document` = 1, again

```
2016-11-14 06:18:01.572 emission[1452:1472530] About to check rw state for config config/consent
2016-11-14 06:18:01.588 emission[1452:1472530] Already have rw-document for key config/consent, nothing to fix

2016-11-14 06:18:01.604 emission[1452:1472530] About to check rw state for config config/sync_config
2016-11-14 06:18:01.622 emission[1452:1472530] For key 1476834909.464491, found document with write_ts = config/sync_config, but not rw-document, changing...
2016-11-14 06:18:01.638 emission[1452:1472530] data has 49 bytes, str has size 49

2016-11-14 06:18:01.651 emission[1452:1472530] About to check rw state for config config/sensor_config
2016-11-14 06:18:01.665 emission[1452:1472530] For key 1478276420.88226, found document with write_ts = config/sensor_config, but not rw-document, changing...
2016-11-14 06:18:01.684 emission[1452:1472530] data has 308 bytes, str has size 308
```

Verify that the rw-documents have been saved correctly to the usercache.

```
sqlite> select * from userCache where KEY = "config/sync_config";
1479133081.63907||America/Los_Angeles|rw-document|config/sync_config||{"ios_use_remote_push":true,"sync_interval":1800}
1476834909.46449|0.0||document|config/sync_config||{"ios_use_remote_push":true,"sync_interval":1800}
```

```
sqlite> select * from userCache where KEY = "config/sensor_config";
1479133081.68492||America/Los_Angeles|rw-document|config/sensor_config||{"is_duty_cycling":true,"filter_distance":1,"accuracy_threshold":200,"simulate_user_interaction":false,"filter_time":-1,"ios_use_remote_push_for_sync":true,"ios_use_visit_notifications_for_detection":true,"geofence_radius":100,"accuracy":-1,"trip_end_stationary_mins":10,"android_geofence_responsiveness":-1}
1478276420.88226|0.0||document|config/sensor_config||{"is_duty_cycling":true,"filter_distance":1,"accuracy_threshold":200,"simulate_user_interaction":false,"filter_time":-1,"ios_use_remote_push_for_sync":true,"ios_use_visit_notifications_for_detection":true,"geofence_radius":100,"accuracy":-1,"trip_end_stationary_mins":10,"android_geofence_responsiveness":-1}
```