### PR TITLE
Final fixes to consent

### DIFF
--- a/src/android/BuiltinUserCache.java
+++ b/src/android/BuiltinUserCache.java
@@ -400,9 +400,10 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         Object[] rwKeys = getValuesFromCursor(checkCursor, false);
         for (int i=0; i < rwKeys.length; i++) {
             String currKey = (String)rwKeys[i];
-            String rwDocDeleteWhereQuery = KEY_TYPE+
-                    " = '"+RW_DOCUMENT_TYPE+"' AND "+KEY_WRITE_TS+
-                    " < MIN("+(long)tq.getEndTs()+", (SELECT MAX("+KEY_WRITE_TS+") FROM "+
+            String rwDocDeleteWhereQuery = KEY_KEY + " = '" + currKey + "' AND "
+                    + KEY_TYPE + " = '"+RW_DOCUMENT_TYPE+"' AND "
+                    +KEY_WRITE_TS + " < MIN("+(long)tq.getEndTs()
+                        +", (SELECT MAX("+KEY_WRITE_TS+") FROM "+
                     TABLE_USER_CACHE + " WHERE (" + KEY_KEY+" = '"+currKey+"' AND "+
                     KEY_TYPE+" = '"+RW_DOCUMENT_TYPE+"')))";
             Log.d(cachedCtx, TAG, "Clearing obsolete RW-DOCUMENTS using "+rwDocDeleteWhereQuery);

--- a/src/ios/BEMBuiltinUserCache.m
+++ b/src/ios/BEMBuiltinUserCache.m
@@ -656,8 +656,8 @@ static BuiltinUserCache *_database;
     NSArray* docResults = [self readSelectResults:checkQuery withMetadata:NO];
     for (int i=0; i < docResults.count; i++) {
         NSString* currKey = docResults[i];
-        NSString* selectQuery = [NSString stringWithFormat:@"SELECT * FROM %@ WHERE %@ = '%@' AND %@ < MIN(%.0f, (SELECT MAX(%@) FROM %@ WHERE (%@ = '%@' AND %@ = '%@')))",
-                                 TABLE_USER_CACHE, KEY_TYPE, RW_DOCUMENT_TYPE, KEY_WRITE_TS, tq.endTs, KEY_WRITE_TS, TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE];
+        NSString* selectQuery = [NSString stringWithFormat:@"SELECT * FROM %@ WHERE %@ = '%@' AND %@ = '%@' AND %@ < MIN(%.0f, (SELECT MAX(%@) FROM %@ WHERE (%@ = '%@' AND %@ = '%@')))",
+                                 TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE, KEY_WRITE_TS, tq.endTs, KEY_WRITE_TS, TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE];
         [LocalNotificationManager addNotification:[NSString stringWithFormat:@"selectQuery = %@", selectQuery] showUI:FALSE];
         NSArray* toDeleteDocs = [self readSelectResults:selectQuery withMetadata:YES];
         for (int j = 0; j < toDeleteDocs.count; j++) {
@@ -665,8 +665,8 @@ static BuiltinUserCache *_database;
         }
         // DELETE FROM TABLE_USER_CACHE WHERE type = 'rw-document) AND
         // write_ts < MIN(tq.endTs, (SELECT MAX(write_ts) FROM userCache WHERE (key = '...' AND TYPE = 'rw-document')))
-        NSString* rwDocDeleteQuery = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@ = '%@' AND %@ < MIN(%.0f, (SELECT MAX(%@) FROM %@ WHERE (%@ = '%@' AND %@ = '%@')))",
-                                      TABLE_USER_CACHE, KEY_TYPE, RW_DOCUMENT_TYPE, KEY_WRITE_TS, tq.endTs, KEY_WRITE_TS, TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE];
+        NSString* rwDocDeleteQuery = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@ = '%@' AND %@ = '%@' AND %@ < MIN(%.0f, (SELECT MAX(%@) FROM %@ WHERE (%@ = '%@' AND %@ = '%@')))",
+                                      TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE, KEY_WRITE_TS, tq.endTs, KEY_WRITE_TS, TABLE_USER_CACHE, KEY_KEY, currKey, KEY_TYPE, RW_DOCUMENT_TYPE];
     [LocalNotificationManager addNotification:[NSString stringWithFormat:@"rwDocDeleteQuery = %@", rwDocDeleteQuery] showUI:FALSE];
     [self clearQuery:rwDocDeleteQuery];
     }


### PR DESCRIPTION
Add the key to the delete queries so that we don't delete the incorrect
obsolete document by mistake. Fixes on both iOS and android. More details in
the issue.

https://github.com/e-mission/cordova-usercache/issues/24#issuecomment-261474390