### PR TITLE
Support local storage shared between javscript and native

### DIFF
--- a/src/android/UserCache.java
+++ b/src/android/UserCache.java
@@ -65,6 +65,7 @@ public interface UserCache {
     public abstract void putMessage(String key, JSONObject value);
     public abstract void putReadWriteDocument(String key, JSONObject value);
 
+
     // Versions that return an object retrieved via GSON. These are intended for use with native code.
     public abstract <T> T[] getMessagesForInterval(int key, TimeQuery tq, Class<T> classOfT);
     public abstract <T> T[] getSensorDataForInterval(int key, TimeQuery tq, Class<T> classOfT);
@@ -88,11 +89,22 @@ public interface UserCache {
     public abstract JSONArray getLastSensorData(String key, int nEntries,
                                                 boolean withMetadata) throws JSONException;
 
+
+    /*
+     * Versions that retrieve temporary configurations that need to be shared between
+     * javascript and native. Functions as standard k-v store, no wrapper classes,
+     * so no object interface.
+     */
+
+    public abstract void putLocalStorage(String key, JSONObject value);
+    public abstract JSONObject getLocalStorage(String key, boolean withMetadata) throws JSONException;
+    public abstract void removeLocalStorage(String key);
         /**
          * Return the document that matches the specified key.
          * The class of T needs to be passed in, and an appropriate type will be reconstructed
          * and returned.
          */
+
     public abstract <T> T getDocument(int key, Class<T> classOfT);
     // Can be either JSONObject or JSONArray, and they don't have a common superclass other than
     // object

--- a/src/android/UserCachePlugin.java
+++ b/src/android/UserCachePlugin.java
@@ -77,6 +77,14 @@ public class UserCachePlugin extends CordovaPlugin {
                     .getLastSensorData(key, nEntries, withMetadata);
             callbackContext.success(result);
             return true;
+        } else if (action.equals("getLocalStorage")) {
+            final String key = data.getString(0);
+            final int nEntries = data.getInt(1);
+            final boolean withMetadata = data.getBoolean(2);
+            JSONObject result = UserCacheFactory.getUserCache(ctxt)
+                    .getLocalStorage(key, withMetadata);
+            callbackContext.success(result);
+            return true;
         } else if (action.equals("putMessage")) {
             final String key = data.getString(0);
             final JSONObject msg = data.getJSONObject(1);
@@ -93,6 +101,25 @@ public class UserCachePlugin extends CordovaPlugin {
             final String key = data.getString(0);
             final JSONObject msg = data.getJSONObject(1);
             UserCacheFactory.getUserCache(ctxt).putSensorData(key, msg);
+            callbackContext.success();
+            return true;
+        } else if (action.equals("putLocalStorage")) {
+            final String key = data.getString(0);
+            final JSONObject msg = data.getJSONObject(1);
+            UserCacheFactory.getUserCache(ctxt).putLocalStorage(key, msg);
+            callbackContext.success();
+            return true;
+        } else if (action.equals("getLocalStorage")) {
+            final String key = data.getString(0);
+            final boolean withMetadata = data.getBoolean(1);
+            JSONObject result = UserCacheFactory.getUserCache(ctxt)
+                    .getLocalStorage(key, withMetadata);
+            callbackContext.success(result);
+            return true;
+        } else if (action.equals("removeLocalStorage")) {
+            final String key = data.getString(0);
+            UserCacheFactory.getUserCache(ctxt)
+                    .removeLocalStorage(key);
             callbackContext.success();
             return true;
         } else if (action.equals("clearEntries")) {

--- a/src/ios/BEMBuiltinUserCache.h
+++ b/src/ios/BEMBuiltinUserCache.h
@@ -54,11 +54,18 @@
 
 - (NSDictionary*) getDocument:(NSString*)key withMetadata:(BOOL)withMetadata;
 
+// Versions that function as a local k-v store, for data to be shared between native and javascript
+// No wrapper classes.
+- (void) putLocalStorage:(NSString*)label jsonValue:(NSDictionary*)value;
+- (NSMutableDictionary*) getLocalStorage:(NSString*) key withMetadata:(BOOL)withMetadata;
+- (void) removeLocalStorage:(NSString*) key;
+
 - (double) getTsOfLastTransition;
 - (NSArray*) syncPhoneToServer;
 - (void) syncServerToPhone:(NSArray*)documentArray;
 
 + (TimeQuery*) getTimeQuery:(NSArray*)pointList;
++ (TimeQuery*) getAllTimeQuery;
 + (NSString*) getTimezone:(NSDictionary*)entry;
 + (NSDate*) getWriteTs:(NSDictionary*)entry;
 

--- a/src/ios/BEMUserCachePlugin.h
+++ b/src/ios/BEMUserCachePlugin.h
@@ -7,11 +7,18 @@
 - (void) getDocument:(CDVInvokedUrlCommand*)command;
 - (void) getSensorDataForInterval:(CDVInvokedUrlCommand*)command;
 - (void) getMessagesForInterval:(CDVInvokedUrlCommand*)command;
+
 - (void) getLastMessages:(CDVInvokedUrlCommand*)command;
 - (void) getLastSensorData:(CDVInvokedUrlCommand *)command;
+
 - (void) putMessage:(CDVInvokedUrlCommand *)command;
 - (void) putRWDocument:(CDVInvokedUrlCommand *)command;
 - (void) putSensorData:(CDVInvokedUrlCommand *)command;
+
+- (void) putLocalStorage:(CDVInvokedUrlCommand *)command;
+- (void) getLocalStorage:(CDVInvokedUrlCommand *)command;
+- (void) removeLocalStorage:(CDVInvokedUrlCommand *)command;
+
 - (void) clearEntries:(CDVInvokedUrlCommand *)command;
 - (void) invalidateCache:(CDVInvokedUrlCommand *)command;
 - (void) clearAll:(CDVInvokedUrlCommand *)command;

--- a/src/ios/BEMUserCachePlugin.m
+++ b/src/ios/BEMUserCachePlugin.m
@@ -101,7 +101,7 @@
         BOOL withMetadata = [[[command arguments] objectAtIndex:2] boolValue];
         NSArray* resultDoc = [[BuiltinUserCache database] getLastMessage:key
                                                                 nEntries:nEntries
-                                                            withMetadata:withMetadata];
+                                                                   withMetadata:withMetadata];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK
                                    messageAsArray:resultDoc];
@@ -189,7 +189,7 @@
     @try {
         NSString* key = [[command arguments] objectAtIndex:0];
         NSDictionary* value = [command.arguments objectAtIndex:1];
-        
+
         [[BuiltinUserCache database] putSensorData:key jsonValue:value];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK];
@@ -202,6 +202,70 @@
                                    messageAsString:msg];
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];
     }
+}
+
+- (void) putLocalStorage:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        NSDictionary* value = [command.arguments objectAtIndex:1];
+        
+        [[BuiltinUserCache database] putLocalStorage:key jsonValue:value];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While putting sensor data, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) getLocalStorage:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        BOOL withMetadata = [[[command arguments] objectAtIndex:1] boolValue];
+        NSDictionary* resultDoc = [[BuiltinUserCache database] getLocalStorage:key
+                                                             withMetadata:withMetadata];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsDictionary:resultDoc];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting messages, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    
+}
+
+- (void) removeLocalStorage:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSString* key = [[command arguments] objectAtIndex:0];
+        [[BuiltinUserCache database] removeLocalStorage:key];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting messages, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+
 }
 
 - (void) clearEntries:(CDVInvokedUrlCommand *)command

--- a/www/usercache.js
+++ b/www/usercache.js
@@ -98,6 +98,24 @@ var UserCache = {
         });
     },
 
+    putLocalStorage: function(key, value) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "putLocalStorage", [key, value]);
+        });
+    },
+
+    getLocalStorage: function(key, withMetadata) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "getLocalStorage", [key, withMetadata]);
+        });
+    },
+
+    removeLocalStorage: function(key) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "removeLocalStorage", [key]);
+        });
+    },
+
     // No putSensorData exposed through javascript since it is not intended for regularly sensed data
     clearAllEntries: function() {
         return UserCache.clearEntries(UserCache.getAllTimeQuery());


### PR DESCRIPTION
Includes both native code changes and javascript interface changes

Add support for a simple k-v store to share data between javascript and native.
We simply support a different type of object in the usercache and ensure that
we don't push it to the server.
    
Note that the interface for this object is slightly different from the others -
- we don't need to delete any of the other data, while we do need to be able to delete the local storage entries
- we return only one entry for each key since it is a k-v store and not a multi-kv store. So this is similar to the getDocument interface.
