### PR TITLE
Add a package.json to allow installing the plugin into cordova

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "em-cordova-usercache",
+  "version": "1.0.0",
+  "description": "Simple package that stores all the connection settings that need to be configured",
+  "cordova": {
+    "id": "em-cordova-usercache",
+    "platforms": [
+      "android",
+      "ios",
+      "windows"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/e-mission/cordova-usercache.git"
+  },
+  "keywords": [
+    "emission",
+    "connection",
+    "settings",
+    "ecosystem:cordova",
+    "cordova-ios",
+    "cordova-android"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.6.0"
+    },
+    {
+      "name": "cordova-android",
+      "version": ">=6.0.0"
+    },
+    {
+      "name": "android-sdk",
+      "version": ">=26"
+    },
+    {
+      "name": "apple-ios",
+      "version": ">=10.0.0"
+    }
+  ],
+  "author": "K. Shankari",
+  "license": "BSD 3-clause",
+  "bugs": {
+    "url": "https://github.com/e-mission/cordova-usercache/issues"
+  },
+  "homepage": "https://e-mission/cordova-usercache"
+}
+


### PR DESCRIPTION
This is part of the cordova-7 changes
https://cordova.apache.org/news/2017/05/04/cordova-7.html

> Platforms and plugins are now required to have a package.json file