### PR TITLE
Address the issue with usercache entries growing continuously

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.usercache"
-        version="1.1.0">
+        version="1.1.1">
 
   <name>UserCache</name>
   <description>Cache messages to and from the server so that we can retrieve

--- a/src/ios/BEMBuiltinUserCache.m
+++ b/src/ios/BEMBuiltinUserCache.m
@@ -663,8 +663,18 @@ static BuiltinUserCache *_database;
     }
 }
 
-+ (TimeQuery*) getTimeQuery:(NSArray*)pointList {
-    assert(pointList.count != 0);
+// The array can contain entries other than points, such as configurations and consent documents.
++ (TimeQuery*) getTimeQuery:(NSArray*)entryList {
+    assert(entryList.count != 0);
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:@"unfiltered entry list (length %lu) runs from %@ to %@", entryList.count, entryList[0], entryList[entryList.count - 1]]];
+    NSPredicate *nonRWPredicate =
+    [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return ![evaluatedObject[@"metadata"][@"type"] isEqual:RW_DOCUMENT_TYPE];
+    }];
+
+    NSArray* pointList = [entryList filteredArrayUsingPredicate:nonRWPredicate];
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:@"filtered entry list (length %lu) runs from %@ to %@", pointList.count, pointList[0], pointList[pointList.count - 1]]];
+
     Metadata* startMd = [Metadata new];
     [DataUtils dictToWrapper:[pointList[0] objectForKey:METADATA_TAG] wrapper:startMd];
     double start_ts = startMd.write_ts;


### PR DESCRIPTION
Ensure that we ignore `config/consent` entries while looking for the range of
motion activities to push to the server

This fixes https://github.com/e-mission/e-mission-docs/issues/434
+ bump up version

@PatGendre, in order to prepare for the new COVID-19 app, I am going through and checking in all my pending changes. So I'm finally checking in the patch for https://github.com/fabmob/e-mission-phone-fabmob/issues/35. You can remove this from your local copy of the plugin and start using the standard plugin again.