### PR TITLE
:sparkles: New methods to return all keys and all local storage keys

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-usercache"
-        version="1.1.5">
+        version="1.1.6">
 
   <name>UserCache</name>
   <description>Cache messages to and from the server so that we can retrieve

--- a/src/android/BuiltinUserCache.java
+++ b/src/android/BuiltinUserCache.java
@@ -489,12 +489,35 @@ public class BuiltinUserCache extends SQLiteOpenHelper implements UserCache {
         Log.i(cachedCtx, TAG, "Deleted " + delDocs + " document entries");
         }
 
-    public void checkAfterPull() {
+    // This private method that returns the object array instead of a JSONArray
+    // is to support reusing the method in checkAfterPull without dealing with
+    // catching or propagating the JSONException throughout
+    public Object[] listAllUniqueKeyObjectList() {
         SQLiteDatabase db = this.getWritableDatabase();
         String checkQuery = "SELECT "+KEY_KEY+" from userCache";
         Cursor queryResult = db.rawQuery(checkQuery, null);
-        Object[] rwKeys = getValuesFromCursor(queryResult, false);
+        Object[] allKeyObjects = getValuesFromCursor(queryResult, false);
+        return allKeyObjects;
+    }
+
+    public void checkAfterPull() {
+        Object[] rwKeys = listAllUniqueKeyObjectList();
         Log.i(cachedCtx, TAG, "After clear complete, cache has "+Arrays.toString(rwKeys)+" entries");
+    }
+
+    public JSONArray listAllUniqueKeys() throws JSONException {
+        Object[] allKeyObjects = listAllUniqueKeyObjectList();
+        JSONArray allKeyStrings = new JSONArray(allKeyObjects);
+        return allKeyStrings;
+    }
+
+    public JSONArray listAllLocalStorageKeys() throws JSONException {
+        SQLiteDatabase db = this.getWritableDatabase();
+        String checkQuery = "SELECT "+KEY_KEY+" from userCache WHERE "+KEY_TYPE+" = '"+LOCAL_STORAGE_TYPE+"'";
+        Cursor queryResult = db.rawQuery(checkQuery, null);
+        Object[] lsKeyObjects = getValuesFromCursor(queryResult, false);
+        JSONArray lsKeyStrings = new JSONArray(lsKeyObjects);
+        return lsKeyStrings;
     }
 
     @Override

--- a/src/android/UserCache.java
+++ b/src/android/UserCache.java
@@ -117,6 +117,14 @@ public interface UserCache {
     // object
     public abstract Object getDocument(String key, boolean withMetadata) throws JSONException;
 
+        /*
+         * Support for debugging mysteriously deleted storage
+         * https://github.com/e-mission/e-mission-docs/issues/932
+         */
+
+    public abstract JSONArray listAllUniqueKeys() throws JSONException;
+    public abstract JSONArray listAllLocalStorageKeys() throws JSONException;
+
     /**
      * Delete documents that match the specified time query.
      * This allows us to support eventual consistency without locking.

--- a/src/android/UserCachePlugin.java
+++ b/src/android/UserCachePlugin.java
@@ -146,6 +146,16 @@ public class UserCachePlugin extends CordovaPlugin {
                     .removeLocalStorage(key);
             callbackContext.success();
             return true;
+        } else if (action.equals("listAllUniqueKeys")) {
+            JSONArray result = UserCacheFactory.getUserCache(ctxt)
+                    .listAllUniqueKeys();
+            callbackContext.success(result);
+            return true;
+        } else if (action.equals("listAllLocalStorageKeys")) {
+            JSONArray result = UserCacheFactory.getUserCache(ctxt)
+                    .listAllLocalStorageKeys();
+            callbackContext.success(result);
+            return true;
         } else if (action.equals("clearEntries")) {
             final JSONObject tqJsonObject = data.getJSONObject(1);
 

--- a/src/ios/BEMBuiltinUserCache.h
+++ b/src/ios/BEMBuiltinUserCache.h
@@ -73,6 +73,9 @@
 + (NSString*) getTimezone:(NSDictionary*)entry;
 + (NSDate*) getWriteTs:(NSDictionary*)entry;
 
+- (NSArray*) listAllUniqueKeys;
+- (NSArray*) listAllLocalStorageKeys;
+
 - (void) clearEntries:(TimeQuery*)tq;
 - (void) clearSupersededRWDocs:(TimeQuery*)tq;
 - (void) clearObsoleteDocs:(TimeQuery*)tq;

--- a/src/ios/BEMBuiltinUserCache.m
+++ b/src/ios/BEMBuiltinUserCache.m
@@ -801,9 +801,20 @@ static BuiltinUserCache *_database;
 }
 
 - (void) checkAfterPull {
+    NSArray* checkResults = [self listAllUniqueKeys];
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:@"After clear complete, cache has entries %@", [checkResults componentsJoinedByString:@", "]] showUI:FALSE];
+}
+
+- (NSArray*) listAllUniqueKeys {
     NSString* checkQuery = [NSString stringWithFormat:@"SELECT DISTINCT(%@) FROM %@", KEY_KEY, TABLE_USER_CACHE];
     NSArray* checkResults = [self readSelectResults:checkQuery withMetadata:NO];
-    [LocalNotificationManager addNotification:[NSString stringWithFormat:@"After clear complete, cache has entries %@", [checkResults componentsJoinedByString:@", "]] showUI:FALSE];
+    return checkResults;
+}
+
+- (NSArray*) listAllLocalStorageKeys {
+    NSString* checkQuery = [NSString stringWithFormat:@"SELECT DISTINCT(%@) FROM %@ WHERE %@ = '%@'", KEY_KEY, TABLE_USER_CACHE, KEY_TYPE, LOCAL_STORAGE_TYPE];
+    NSArray* checkResults = [self readSelectResults:checkQuery withMetadata:NO];
+    return checkResults;
 }
 
 - (void)invalidateCache:(TimeQuery *)tq

--- a/src/ios/BEMUserCachePlugin.h
+++ b/src/ios/BEMUserCachePlugin.h
@@ -21,6 +21,9 @@
 - (void) getLocalStorage:(CDVInvokedUrlCommand *)command;
 - (void) removeLocalStorage:(CDVInvokedUrlCommand *)command;
 
+- (void) listAllUniqueKeys:(CDVInvokedUrlCommand *)command;
+- (void) listAllLocalStorageKeys:(CDVInvokedUrlCommand *)command;
+
 - (void) clearEntries:(CDVInvokedUrlCommand *)command;
 - (void) invalidateCache:(CDVInvokedUrlCommand *)command;
 - (void) clearAll:(CDVInvokedUrlCommand *)command;

--- a/src/ios/BEMUserCachePlugin.m
+++ b/src/ios/BEMUserCachePlugin.m
@@ -318,6 +318,45 @@
 
 }
 
+
+- (void) listAllUniqueKeys:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSArray* resultDoc = [[BuiltinUserCache database] listAllUniqueKeys];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsArray:resultDoc];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting sensor data, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
+- (void) listAllLocalStorageKeys:(CDVInvokedUrlCommand *)command
+{
+    NSString* callbackId = [command callbackId];
+    @try {
+        NSArray* resultDoc = [[BuiltinUserCache database] listAllLocalStorageKeys];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_OK
+                                   messageAsArray:resultDoc];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+    @catch (NSException *exception) {
+        NSString* msg = [NSString stringWithFormat: @"While getting sensor data, error %@", exception];
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:msg];
+        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    }
+}
+
 - (void) clearEntries:(CDVInvokedUrlCommand *)command
 {
     NSString* callbackId = [command callbackId];

--- a/www/usercache.js
+++ b/www/usercache.js
@@ -127,7 +127,18 @@ var UserCache = {
             exec(resolve, reject, "UserCache", "removeLocalStorage", [key]);
         });
     },
-
+    // help debug missing/deleted storage
+    // https://github.com/e-mission/e-mission-docs/issues/932
+    listAllUniqueKeys: function() {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "listAllUniqueKeys", []);
+        });
+    },
+    listAllLocalStorageKeys: function() {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "UserCache", "listAllLocalStorageKeys", []);
+        });
+    },
     // No putSensorData exposed through javascript since it is not intended for regularly sensed data
     clearAllEntries: function() {
         return UserCache.clearEntries(UserCache.getAllTimeQuery());


### PR DESCRIPTION
The list of all keys is just for debugging. It allows us to answer the question: "when these local storage entries are deleted, is everything deleted? Or is there something special/unique about local storage?"

It would be pretty terrible if we are losing actual background information as well, since we would be losing trip data as well.

The list of local storage keys will actually be used in the phone code for working around the issue that the SQLite entries of the local storage type are sometimes deleted.
https://github.com/e-mission/e-mission-docs/issues/930

We already had an issue in which the webview based local storage was getting arbitrarily deleted.

Since either of the entries can be deleted, we treat don't treat one as primary and the other as secondary. Instead, we treat them as co-equal, duplicate entries (similar to RAID :). We will use the keys to determine which ones are missing from each of the copies and copy them over properly.