### PR TITLE
Local storage bounding for iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-usercache",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Cache messages to and from the server so that we can retrieve them quickly",
   "license": "BSD-3-clause",
   "cordova": {

--- a/src/ios/BEMBuiltinUserCache.h
+++ b/src/ios/BEMBuiltinUserCache.h
@@ -24,7 +24,6 @@
 -(NSString*) getStatName:(NSString*)plistKey;
 
 // We implement the same interface as the android code, to use somewhat tested code
-- (NSArray *)getLastValues:(NSString *)label nEntries:(NSInteger)nEntries;
 
 // Versions that save wrapper classes, for use with native code
 - (void) putSensorData:(NSString*) label value:(NSObject*)value;

--- a/src/ios/BEMBuiltinUserCache.h
+++ b/src/ios/BEMBuiltinUserCache.h
@@ -24,6 +24,7 @@
 -(NSString*) getStatName:(NSString*)plistKey;
 
 // We implement the same interface as the android code, to use somewhat tested code
+- (NSArray *)getLastValues:(NSString *)label nEntries:(NSInteger)nEntries;
 
 // Versions that save wrapper classes, for use with native code
 - (void) putSensorData:(NSString*) label value:(NSObject*)value;


### PR DESCRIPTION
This change is a continuation of [issue 1020](https://github.com/e-mission/e-mission-docs/issues/1020) in which we were putting a bound on the number of entries that can be stored under a specific key in the local storage. The iOS change is now finished, I essentially copied the same code I used from the Android change and just implemented it here. For testing I did the same thing that I did in the Android version. I added `BOUND+1` entries of dummy data to `"CURR_GEOFENCE_LOCATION"`, and then I ran the code, making sure that we were left with only `BOUND-1` number of  previous entries, and then the current entry. I attached a log file below that demonstrates the `BOUND+1` test that I did, given that `BOUND = 3`. At the very start you can see that I added 4 filler `NSDictionary` values to the local storage, and then at the end of the file we end up with only 2 of those filler `NSDictionary` objects, and the 1 actual `CURR_GEOFENCE_LOCATION` value.


[bounding_local_storage_ios.pdf](https://github.com/e-mission/cordova-usercache/files/13822751/bounding_local_storage_ios.pdf)
