### PR TITLE
Add "app_config" to usercache keys

### DIFF
--- a/res/android/usercachekeys.xml
+++ b/res/android/usercachekeys.xml
@@ -12,5 +12,6 @@
     <string name="key.usercache.client_time">stats/client_time</string>
     <string name="key.usercache.client_nav_event">stats/client_nav_event</string>
     <string name="key.usercache.client_error">stats/client_error</string>
+    <string name="key.usercache.app_config">config/app_ui_config</string>
     <string name="metadata.usercache.write_ts">write_ts</string>
 </resources>

--- a/res/ios/usercachekeys.plist
+++ b/res/ios/usercachekeys.plist
@@ -26,8 +26,8 @@
 	<string>stats/client_nav_event</string>
 	<key>key.usercache.client_error</key>
 	<string>stats/client_error</string>
-  <key>key.usercache.app_config</key>
-  <string>config/app_ui_config</string>
+	<key>key.usercache.app_config</key>
+	<string>config/app_ui_config</string>
 	<key>metadata.usercache.write_ts</key>
 	<string>write_ts</string>
 </dict>

--- a/res/ios/usercachekeys.plist
+++ b/res/ios/usercachekeys.plist
@@ -26,6 +26,8 @@
 	<string>stats/client_nav_event</string>
 	<key>key.usercache.client_error</key>
 	<string>stats/client_error</string>
+  <key>key.usercache.app_config</key>
+  <string>config/app_ui_config</string>
 	<key>metadata.usercache.write_ts</key>
 	<string>write_ts</string>
 </dict>


### PR DESCRIPTION
The app config is stored as a document under the key "config/app_ui_config".

With this key added, we will now be able to query the usercache for the app config from other parts of the native code.